### PR TITLE
[refactor] 대학별 진행중인 축제 조회 API 응답값 수정 및 배너에 사용되는 뱃지 컴포넌트 생성

### DIFF
--- a/src/components/Indicator.tsx
+++ b/src/components/Indicator.tsx
@@ -1,0 +1,26 @@
+import { Badge } from "./ui/badge";
+
+import { cn } from "@/lib/utils";
+
+interface IndicatorBadge {
+  title: string;
+  rounded?: boolean;
+}
+
+const Indicator = (props: IndicatorBadge) => {
+  const { title, rounded } = props;
+
+  return (
+    <Badge
+      className={cn(
+        "absolute left-6 top-2",
+        rounded ? "rounded-lg" : "rounded-md",
+      )}
+      variant="banner"
+    >
+      {title}
+    </Badge>
+  );
+};
+
+export default Indicator;

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 dark:border-slate-800 dark:focus:ring-slate-300",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80",
+        secondary:
+          "border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
+        destructive:
+          "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/80",
+        outline: "text-slate-950 dark:text-slate-50",
+        banner: "border-transparent bg-[#f2f2f2c1] text-[#5E5E6E]",
+        reservation: "border-transparent bg-[#17171B] text-[#81B0FE]",
+        enter: "border-transparent bg-[#ffffff] text-[#9981FE]",
+        deposit: "border-transparent bg-[#5E5E6E] text-[#FFEF60]",
+        darkreservation: "border-transparent bg-[#81B0FE] text-[#17171B]",
+        darkenter: "border-transparent bg-[#9981FE] text-[#ffffff]",
+        darkdeposit: "border-transparent bg-[#FFEF60] text-[#5E5E6E]",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/pages/home/_components/carousel/Carousel.tsx
+++ b/src/pages/home/_components/carousel/Carousel.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from "react";
 import useEmblaCarousel from "embla-carousel-react";
 import { EmblaCarouselType, EmblaOptionsType } from "embla-carousel";
 
+import Indicator from "@/components/Indicator";
+
 import { useDotButton } from "@/hooks/useDotButton";
 
 import { FestivalInfo } from "@/types/univType";
@@ -42,13 +44,15 @@ const Carousel = (props: PropType) => {
       </p>
     </div>
   ) : (
-    slides.map(({ url }, index) => (
-      <LazyLoadImage
-        key={index}
-        index={index}
-        imgSrc={url}
-        inView={slidesInView.indexOf(index) > -1}
-      />
+    slides.map(({ title, url }, index) => (
+      <div className="embla__slide relative" key={url}>
+        <LazyLoadImage
+          index={index}
+          imgSrc={url}
+          inView={slidesInView.indexOf(index) > -1}
+        />
+        <Indicator title={title} />
+      </div>
     ))
   );
 
@@ -73,7 +77,7 @@ const Carousel = (props: PropType) => {
                 key={index}
                 onClick={() => onDotButtonClick(index)}
                 className={"embla__dot".concat(
-                  index === selectedIndex ? "embla__dot--selected" : "",
+                  index === selectedIndex ? " embla__dot--selected" : "",
                 )}
               />
             ))}

--- a/src/pages/home/_components/carousel/CarouselLazyImage.tsx
+++ b/src/pages/home/_components/carousel/CarouselLazyImage.tsx
@@ -17,7 +17,7 @@ export const LazyLoadImage = (props: PropType) => {
   }, [inView, setHasLoaded]);
 
   return (
-    <div className="embla__slide">
+    <>
       {!hasLoaded && <Skeleton className="h-full w-full" />}
       {inView && (
         <img
@@ -28,6 +28,6 @@ export const LazyLoadImage = (props: PropType) => {
           data-src={imgSrc}
         />
       )}
-    </div>
+    </>
   );
 };

--- a/src/types/univType.ts
+++ b/src/types/univType.ts
@@ -4,7 +4,7 @@ export type FestivalInfo = {
   startDate: string;
   endDate: string;
   location: string;
-  banners: { url: string }[];
+  banners: { title: string; url: string }[];
 };
 
 export type FestivalInfoResponse = FestivalInfo;


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호

issue #26 
## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 대학별 진행중인 축제 조회 API의 응답값을 수정했습니다.
  - 새로 추가된 title 프로퍼티를 가져옵니다.
- [x] 뱃지 컴포넌트인 Indicator를 생성했습니다.
  - 해당 뱃지 컴포넌트는 `4. 티켓 확인 및 6. 티켓 상세`에서도 사용되기에, shadcn의 badge에 variant를 추가했습니다.
- [x] 뱃지 컴포넌트를 배너에 추가했습니다.

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점
- `4. 티켓 확인 및 6. 티켓 상세`에서 사용되는 입금 확인중, 예매 완료 등의 뱃지는 variant로 접근해서 사용하시면 됩니다.
## 💬 리뷰 요구사항(선택)


---
🚨 **이슈를 닫아주세요!**
> ex) close #이슈번호

close #26 