### PR TITLE
style: 티켓 예매 스타일 수정

### DIFF
--- a/apps/user/src/api/show.ts
+++ b/apps/user/src/api/show.ts
@@ -19,14 +19,17 @@ export const getShowList = async (id: string | null) => {
     },
   });
 
-  return data.shows;
+  return { reservationUserType: data.reservationUserType, shows: data.shows };
 };
 
-export const getReservationList = async (id: string | null) => {
+export const getReservationList = async (
+  id: string | null,
+  reservationUserType: string | null,
+) => {
   const accessToken = getAccessToken();
 
   const { data } = await instance.get<ReservationInfoResponse>(
-    `/events/shows/${id}/reservations`,
+    `/events/shows/${id}/reservations/${reservationUserType}`,
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,

--- a/apps/user/src/components/fallback/BuyTicketErrorFallback.tsx
+++ b/apps/user/src/components/fallback/BuyTicketErrorFallback.tsx
@@ -1,0 +1,52 @@
+import { FallbackProps } from "react-error-boundary";
+import { Button } from "@uket/ui/components/ui/button";
+
+
+import Logo from "../Logo";
+import {
+  ErrorContainer,
+  ErrorDescription,
+  ErrorHeader,
+  ErrorTitle,
+} from "../error/CustomError";
+
+import { useNavigate } from "@/router";
+
+const BuyTicketErrorFallback = (props: FallbackProps) => {
+  const navigate = useNavigate();
+  const { resetErrorBoundary } = props;
+
+  const back = () => {
+    navigate(-1);
+    resetErrorBoundary();
+  };
+
+  return (
+    <ErrorContainer className="flex-col gap-10">
+      <Logo />
+      <ErrorHeader className="text-center">
+        <ErrorTitle className="text-xl">잠시 후 다시 시도해 주세요!</ErrorTitle>
+        <ErrorDescription className="pt-3">
+          티켓 예매 과정에 에러가 발생했습니다. <br />
+          잠시 후 다시 시도해 주세요.
+        </ErrorDescription>
+      </ErrorHeader>
+      <footer className="flex w-full flex-col gap-2 px-5">
+        <Button
+          onClick={resetErrorBoundary}
+          className="rounded-xl border border-[#5E5E6E] bg-[#5E5E6E] py-6 text-xs font-bold hover:bg-[#777784]"
+        >
+          다시 시도
+        </Button>
+        <Button
+          onClick={back}
+          className="rounded-xl border border-[#5E5E6E] bg-white py-6 text-xs font-bold text-[#5E5E6E] hover:bg-slate-100"
+        >
+          이전 페이지로
+        </Button>
+      </footer>
+    </ErrorContainer>
+  );
+};
+
+export default BuyTicketErrorFallback;

--- a/apps/user/src/hooks/queries/useQueryReservationList.ts
+++ b/apps/user/src/hooks/queries/useQueryReservationList.ts
@@ -2,10 +2,13 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { getReservationList } from "@/api/show";
 
-export const useQueryReservationList = (id: string | null) => {
+export const useQueryReservationList = (
+  id: string | null,
+  reservationUserType: string | null,
+) => {
   const { data, error } = useSuspenseQuery({
-    queryKey: ["reservation-info", id],
-    queryFn: () => getReservationList(id),
+    queryKey: ["reservation-info", id, reservationUserType],
+    queryFn: () => getReservationList(id, reservationUserType),
   });
 
   if (error) {

--- a/apps/user/src/hooks/queries/useQueryShowList.ts
+++ b/apps/user/src/hooks/queries/useQueryShowList.ts
@@ -11,6 +11,5 @@ export const useQueryShowList = (id: string | null) => {
   if (error) {
     throw error;
   }
-
   return { data };
 };

--- a/apps/user/src/hooks/useReservationSelection.ts
+++ b/apps/user/src/hooks/useReservationSelection.ts
@@ -1,13 +1,31 @@
 import { useState } from "react";
 
-export const useReservationSelection = (initialStart = "", initialEnd = "") => {
-  const [selectedStartTime, setSelectedStartTme] = useState(initialStart);
-  const [selectedEndTime, setSelectedEndTme] = useState(initialEnd);
+import { FormType } from "./useTicketStackForm";
+import useItemSelect from "./useItemSelect";
+
+export const useReservationSelection = (form: FormType) => {
+  const [selectedStartTime, setSelectedStartTme] = useState("");
+  const [selectedEndTime, setSelectedEndTme] = useState("");
+
+  const { selectedItem, handleSelectItem } = useItemSelect();
+
+  const handleSelectReservation = (
+    id: number,
+    startTime: string,
+    endTime: string,
+  ) => {
+    handleSelectItem(id);
+    form.setValue("reservationId", id);
+    setSelectedStartTme(startTime);
+    setSelectedEndTme(endTime);
+  };
 
   return {
+    selectedItem,
     selectedStartTime,
     setSelectedStartTme,
     selectedEndTime,
     setSelectedEndTme,
+    handleSelectReservation,
   };
 };

--- a/apps/user/src/hooks/useReservationSelection.ts
+++ b/apps/user/src/hooks/useReservationSelection.ts
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+export const useReservationSelection = (initialStart = "", initialEnd = "") => {
+  const [selectedStartTime, setSelectedStartTme] = useState(initialStart);
+  const [selectedEndTime, setSelectedEndTme] = useState(initialEnd);
+
+  return {
+    selectedStartTime,
+    setSelectedStartTme,
+    selectedEndTime,
+    setSelectedEndTme,
+  };
+};

--- a/apps/user/src/hooks/useReservationUserType.ts
+++ b/apps/user/src/hooks/useReservationUserType.ts
@@ -1,0 +1,16 @@
+import { useState } from "react";
+
+const useReservationUserType = () => {
+  const [reservationUserType, setReservationUserType] = useState<string>("");
+
+  const handleReservationUserType = (reservationType: string) => {
+    setReservationUserType(reservationType);
+  };
+
+  return {
+    reservationUserType,
+    handleReservationUserType,
+  };
+};
+
+export default useReservationUserType;

--- a/apps/user/src/hooks/useShowSelections.ts
+++ b/apps/user/src/hooks/useShowSelections.ts
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
-export const useShowSelection = (initialDate = "", initialName = "") => {
-  const [selectedShowDate, setSelectedShowDate] = useState(initialDate);
-  const [selectedShowName, setSelectedShowName] = useState(initialName);
+export const useShowSelection = () => {
+  const [selectedShowDate, setSelectedShowDate] = useState("");
+  const [selectedShowName, setSelectedShowName] = useState("");
 
   return {
     selectedShowDate,

--- a/apps/user/src/pages/buy-ticket/_components/Activity.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/Activity.tsx
@@ -32,7 +32,7 @@ const ActivityContent = ({
     <main className="flex h-full flex-col items-center overflow-y-scroll bg-[#F2F2F2]">
       <section
         className={cn(
-          "flex w-full grow flex-col justify-center gap-4  pt-4",
+          "flex w-full grow flex-col justify-center gap-4",
           className,
         )}
         {...props}

--- a/apps/user/src/pages/buy-ticket/_components/DateActivity.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/DateActivity.tsx
@@ -1,15 +1,12 @@
-import { Suspense } from "react";
 import { ActivityComponentType } from "@stackflow/react";
 import { AppScreen } from "@stackflow/plugin-basic-ui";
-
-import RetryErrorBoundary from "@/components/error/RetryErrorBoundary";
 
 import { useTicketStackForm } from "@/hooks/useTicketStackForm";
 import { useShowSelection } from "@/hooks/useShowSelections";
 import useItemSelect from "@/hooks/useItemSelect";
 import { useFormatTime } from "@/hooks/useFormatTime";
 import useDateTicketParams from "@/hooks/useDateTicketParams";
-
+import { useQueryShowList } from "@/hooks/queries/useQueryShowList";
 
 import ShowList from "./ShowList";
 import SelectTicketItem from "./SelectTicketItem";
@@ -24,6 +21,9 @@ import {
 
 const DateActivity: ActivityComponentType = () => {
   const { univName, univId, eventId, setTicketParams } = useDateTicketParams();
+
+  const { data } = useQueryShowList(eventId);
+  const { reservationUserType, shows } = data;
 
   const { form } = useTicketStackForm();
   form.setValue("universityId", parseInt(univId!, 10));
@@ -55,6 +55,10 @@ const DateActivity: ActivityComponentType = () => {
     <AppScreen appBar={{ border: false, height: "56px" }}>
       <Activity>
         <ActivityContent>
+          <div className="flex gap-5 px-[22px]">
+            <div>{univName}</div>
+            <div>{reservationUserType}</div>
+          </div>
           <div className="flex gap-3 px-[22px] pb-4">
             <SelectTicketItem title="선택 학교" content={univName!} />
           </div>
@@ -62,21 +66,21 @@ const DateActivity: ActivityComponentType = () => {
             <HeaderItem step={"01"} content={"예매 날짜를 선택해 주세요."} />
           </ActivityHeader>
 
-          <RetryErrorBoundary>
-            <Suspense>
-              <ShowList
-                eventId={eventId.toString()}
-                selectedItem={selectedItem}
-                onSelect={handleSelectDate}
-              />
-            </Suspense>
-          </RetryErrorBoundary>
+          <ShowList
+            shows={shows}
+            selectedItem={selectedItem}
+            onSelect={handleSelectDate}
+          />
 
           <ActivityFooter>
             <NextButton
               activityName={"TimeActivity" as never}
               disabled={selectedItem === null}
-              params={{ showDate: formatShowDate, form }}
+              params={{
+                showDate: formatShowDate,
+                reservationUserType: reservationUserType,
+                form,
+              }}
             ></NextButton>
           </ActivityFooter>
         </ActivityContent>

--- a/apps/user/src/pages/buy-ticket/_components/DateActivity.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/DateActivity.tsx
@@ -9,7 +9,7 @@ import useDateTicketParams from "@/hooks/useDateTicketParams";
 import { useQueryShowList } from "@/hooks/queries/useQueryShowList";
 
 import ShowList from "./ShowList";
-import SelectTicketItem from "./SelectTicketItem";
+import SelectHeader from "./SelectHeader";
 import NextButton from "./NextButton";
 import HeaderItem from "./HeaderItem";
 import {
@@ -49,19 +49,21 @@ const DateActivity: ActivityComponentType = () => {
   };
 
   const { formatDate } = useFormatTime(selectedShowDate);
-  const formatShowDate = `${selectedShowName} (${formatDate.slice(2)})`;
+  const formatShowDate =
+    selectedShowDate !== ""
+      ? `${selectedShowName} (${formatDate.slice(2)})`
+      : "";
 
   return (
     <AppScreen appBar={{ border: false, height: "56px" }}>
       <Activity>
         <ActivityContent>
-          <div className="flex gap-5 px-[22px]">
-            <div>{univName}</div>
-            <div>{reservationUserType}</div>
-          </div>
-          <div className="flex gap-3 px-[22px] pb-4">
-            <SelectTicketItem title="선택 학교" content={univName!} />
-          </div>
+          <SelectHeader
+            univName={univName}
+            reservationUserType={reservationUserType}
+            formatShowDate={formatShowDate}
+          />
+
           <ActivityHeader className="px-[22px]">
             <HeaderItem step={"01"} content={"예매 날짜를 선택해 주세요."} />
           </ActivityHeader>

--- a/apps/user/src/pages/buy-ticket/_components/DateItem.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/DateItem.tsx
@@ -1,10 +1,13 @@
 import { useState, useEffect } from "react";
-import { cn } from "@uket/ui/lib/utils";
 
 import { useFormatTime } from "@/hooks/useFormatTime";
 
 import TicketQuantityItem from "./TicketQuantityItem";
-import CircleButton from "./CircleButton";
+import TicketHeader from "./TicketHeader";
+import TicketFooter from "./TicketFooter";
+import TicketDivider from "./TicketDivider";
+import TicketContainer from "./TicketContainer";
+import Overlay from "./Overlay";
 
 interface DateItemProps {
   name: string;
@@ -31,17 +34,12 @@ const DateItem = (props: DateItemProps) => {
   const [isSoldOut, setIsSoldOut] = useState(false);
 
   useEffect(() => {
-    if (totalTicketCount === 0) {
-      setIsSoldOut(true);
-    } else {
-      setIsSoldOut(false);
-    }
+    setIsSoldOut(totalTicketCount === 0);
   }, [totalTicketCount]);
 
   useEffect(() => {
     const currentTime = new Date().getTime();
     const ticketingTime = new Date(ticketingDate).getTime();
-
     setIsDisabled(currentTime < ticketingTime);
   }, [ticketingDate]);
 
@@ -54,35 +52,26 @@ const DateItem = (props: DateItemProps) => {
   return (
     <div className="relative">
       {isDisabled && (
-        <div className="absolute inset-0 z-50 flex items-center justify-center text-xs font-bold text-red-500">
-          {formatTicketingDate} {formatTicketingTime}부터 예매 가능합니다.
-        </div>
+        <Overlay
+          message={`${formatTicketingDate} ${formatTicketingTime}부터 예매 가능합니다.`}
+        />
       )}
-      {isSoldOut && (
-        <div className="absolute inset-y-0 right-3 z-50 flex w-12 items-center justify-center bg-[#D9D9D9]">
-          <div className="rotate-90 text-xs font-bold text-[#FD724F]">
-            SOLDOUT
-          </div>
-        </div>
-      )}
-      <div
-        className={cn(
-          "z-40 flex w-full flex-col gap-[9px] rounded-lg bg-white px-5 pb-[15px] pt-[17px] shadow-lg",
-          (isDisabled || isSoldOut) &&
-            "pointer-events-none bg-[#D9D9D9] opacity-60",
-        )}
-        onClick={onSelect}
+      {isSoldOut && <Overlay message="SOLDOUT" soldOut />}
+
+      <TicketContainer
+        isDisabled={isDisabled}
+        isSoldOut={isSoldOut}
+        onSelect={onSelect}
       >
-        <div className="flex justify-between">
-          <div className="text-[42px] font-black">{name}</div>
-          <div className="self-center">
-            <CircleButton isSelected={isSelected} />
-          </div>
-        </div>
+        <TicketHeader
+          title={name}
+          fontStyle="text-[42px] font-black"
+          isSelected={isSelected}
+        />
 
-        <div className="my-[1%] w-full border-[0.5px] border-[#CCCCCC]"></div>
+        <TicketDivider />
 
-        <div className="flex gap-10 text-xs">
+        <TicketFooter>
           <div className="flex gap-2">
             <p className="font-medium">일시</p>
             <div>
@@ -97,8 +86,8 @@ const DateItem = (props: DateItemProps) => {
             amount={totalTicketCount}
             color="5E5E6E"
           />
-        </div>
-      </div>
+        </TicketFooter>
+      </TicketContainer>
     </div>
   );
 };

--- a/apps/user/src/pages/buy-ticket/_components/DateItem.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/DateItem.tsx
@@ -34,7 +34,7 @@ const DateItem = (props: DateItemProps) => {
   const [isSoldOut, setIsSoldOut] = useState(false);
 
   useEffect(() => {
-    setIsSoldOut(totalTicketCount === 0);
+    setIsSoldOut(totalTicketCount <= 0);
   }, [totalTicketCount]);
 
   useEffect(() => {
@@ -56,7 +56,7 @@ const DateItem = (props: DateItemProps) => {
           message={`${formatTicketingDate} ${formatTicketingTime}부터 예매 가능합니다.`}
         />
       )}
-      {isSoldOut && <Overlay message="SOLDOUT" soldOut />}
+      {isSoldOut && !isDisabled && <Overlay message="SOLDOUT" soldOut />}
 
       <TicketContainer
         isDisabled={isDisabled}

--- a/apps/user/src/pages/buy-ticket/_components/DateItem.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/DateItem.tsx
@@ -68,9 +68,7 @@ const DateItem = (props: DateItemProps) => {
           fontStyle="text-[42px] font-black"
           isSelected={isSelected}
         />
-
         <TicketDivider />
-
         <TicketFooter>
           <div className="flex gap-2">
             <p className="font-medium">일시</p>

--- a/apps/user/src/pages/buy-ticket/_components/DateItem.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/DateItem.tsx
@@ -28,16 +28,21 @@ const DateItem = (props: DateItemProps) => {
   } = props;
 
   const [isDisabled, setIsDisabled] = useState(false);
+  const [isSoldOut, setIsSoldOut] = useState(false);
+
+  useEffect(() => {
+    if (totalTicketCount === 0) {
+      setIsSoldOut(true);
+    } else {
+      setIsSoldOut(false);
+    }
+  }, [totalTicketCount]);
 
   useEffect(() => {
     const currentTime = new Date().getTime();
     const ticketingTime = new Date(ticketingDate).getTime();
 
-    if (currentTime < ticketingTime) {
-      setIsDisabled(true);
-    } else {
-      setIsDisabled(false);
-    }
+    setIsDisabled(currentTime < ticketingTime);
   }, [ticketingDate]);
 
   const { formatDate: formatShowDate, formatTime: formatStartTime } =
@@ -49,14 +54,22 @@ const DateItem = (props: DateItemProps) => {
   return (
     <div className="relative">
       {isDisabled && (
-        <div className="absolute inset-0 flex items-center justify-center text-xs font-bold text-red-500">
+        <div className="absolute inset-0 z-50 flex items-center justify-center text-xs font-bold text-red-500">
           {formatTicketingDate} {formatTicketingTime}부터 예매 가능합니다.
+        </div>
+      )}
+      {isSoldOut && (
+        <div className="absolute inset-y-0 right-3 z-50 flex w-12 items-center justify-center bg-[#D9D9D9]">
+          <div className="rotate-90 text-xs font-bold text-[#FD724F]">
+            SOLDOUT
+          </div>
         </div>
       )}
       <div
         className={cn(
-          "flex w-full flex-col gap-[9px] rounded-lg bg-white px-5 pb-[15px] pt-[17px] shadow-lg",
-          isDisabled && "pointer-events-none bg-[#5E5E6E] opacity-25",
+          "z-40 flex w-full flex-col gap-[9px] rounded-lg bg-white px-5 pb-[15px] pt-[17px] shadow-lg",
+          (isDisabled || isSoldOut) &&
+            "pointer-events-none bg-[#D9D9D9] opacity-60",
         )}
         onClick={onSelect}
       >

--- a/apps/user/src/pages/buy-ticket/_components/NextButton.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/NextButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@uket/ui/components/ui/button";
 
+
 import { FormType, useTicketStackForm } from "@/hooks/useTicketStackForm";
 
 import { useTicketFlow } from "@/utils/useTicketFlow";

--- a/apps/user/src/pages/buy-ticket/_components/Overlay.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/Overlay.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@uket/ui/lib/utils";
+
+interface OverlayProps {
+  message: string;
+  soldOut?: boolean;
+}
+
+const Overlay = (props: OverlayProps) => {
+  const { message, soldOut } = props;
+
+  return (
+    <div
+      className={cn(
+        "absolute inset-y-0 z-50 flex items-center justify-center text-xs font-bold",
+        soldOut ? "right-3 w-12 bg-[#D9D9D9]" : "inset-x-0",
+      )}
+    >
+      <div className={cn("text-[#FD724F]", soldOut && "rotate-90")}>
+        {message}
+      </div>
+    </div>
+  );
+};
+
+export default Overlay;

--- a/apps/user/src/pages/buy-ticket/_components/ReservationList.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/ReservationList.tsx
@@ -5,7 +5,7 @@ import TimeItem from "./TimeItem";
 interface ReservationListProps {
   reservationList: ReservationInfo[];
   selectedItem: number | null;
-  onSelect: (id: number) => void;
+  onSelect: (id: number, startTime: string, endTime: string) => void;
 }
 
 const ReservationList = (props: ReservationListProps) => {
@@ -22,7 +22,7 @@ const ReservationList = (props: ReservationListProps) => {
             reservedCount={reservedCount}
             totalCount={totalCount}
             isSelected={selectedItem === id}
-            onSelect={() => onSelect(id)}
+            onSelect={() => onSelect(id, startTime, endTime)}
           />
         ),
       )}

--- a/apps/user/src/pages/buy-ticket/_components/ReservationList.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/ReservationList.tsx
@@ -1,16 +1,15 @@
-import { useQueryReservationList } from "@/hooks/queries/useQueryReservationList";
+import { ReservationInfo } from "@/types/showType";
 
 import TimeItem from "./TimeItem";
 
 interface ReservationListProps {
-  showId: string;
+  reservationList: ReservationInfo[];
   selectedItem: number | null;
   onSelect: (id: number) => void;
 }
 
 const ReservationList = (props: ReservationListProps) => {
-  const { showId, selectedItem, onSelect } = props;
-  const { data: reservationList } = useQueryReservationList(showId);
+  const { reservationList, selectedItem, onSelect } = props;
 
   return (
     <div className="flex flex-col gap-4 px-[22px]">

--- a/apps/user/src/pages/buy-ticket/_components/ReservationList.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/ReservationList.tsx
@@ -1,15 +1,21 @@
-import { ReservationInfo } from "@/types/showType";
+import { useQueryReservationList } from "@/hooks/queries/useQueryReservationList";
 
 import TimeItem from "./TimeItem";
 
 interface ReservationListProps {
-  reservationList: ReservationInfo[];
+  showId: string;
   selectedItem: number | null;
   onSelect: (id: number, startTime: string, endTime: string) => void;
+  reservationUserType: string;
 }
 
 const ReservationList = (props: ReservationListProps) => {
-  const { reservationList, selectedItem, onSelect } = props;
+  const { showId, selectedItem, onSelect, reservationUserType } = props;
+
+  const { data: reservationList } = useQueryReservationList(
+    showId,
+    reservationUserType,
+  );
 
   return (
     <div className="flex flex-col gap-4 px-[22px]">

--- a/apps/user/src/pages/buy-ticket/_components/SelectHeader.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/SelectHeader.tsx
@@ -1,0 +1,30 @@
+import SelectTicketItem from "./SelectTicketItem";
+
+interface SelectHeaderProps {
+  univName: string | null;
+  reservationUserType: string;
+  formatShowDate: string;
+  formatSelectTime?: string;
+}
+
+const SelectHeader = (props: SelectHeaderProps) => {
+  const { univName, reservationUserType, formatShowDate, formatSelectTime } =
+    props;
+
+  return (
+    <div className="flex flex-col gap-2 bg-white pt-3">
+      <div className="flex items-center gap-2 px-[22px]">
+        <div className="text-lg font-bold">{univName}</div>
+        <div className="text-sm font-semibold text-[#724FFD]">
+          {reservationUserType}
+        </div>
+      </div>
+      <div className="flex gap-3 px-[22px] pb-4">
+        <SelectTicketItem title="선택 날짜" content={formatShowDate} />
+        <SelectTicketItem title="선택 시간" content={formatSelectTime ?? ""} />
+      </div>
+    </div>
+  );
+};
+
+export default SelectHeader;

--- a/apps/user/src/pages/buy-ticket/_components/SelectTicketItem.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/SelectTicketItem.tsx
@@ -1,13 +1,13 @@
 interface SelectTicketItemProps {
-  title: string;
-  content: string;
+  title?: string;
+  content?: string;
 }
 
 const SelectTicketItem = (props: SelectTicketItemProps) => {
   const { title, content } = props;
 
   return (
-    <div className="flex h-[32px] w-[162px] items-center gap-1.5 rounded-md bg-[#D9D9D9] pl-3 text-[10px]">
+    <div className="flex h-[32px] w-1/2 items-center gap-1.5 rounded-md border-[0.5px] border-[#D9D9D9] bg-[#F2F2F2] pl-3 text-[10px]">
       <div>{title}</div>
       <div className="font-bold">{content}</div>
     </div>

--- a/apps/user/src/pages/buy-ticket/_components/ShowList.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/ShowList.tsx
@@ -1,15 +1,25 @@
-import { ShowInfo } from "@/types/showType";
+import { useEffect } from "react";
+
+import { useQueryShowList } from "@/hooks/queries/useQueryShowList";
 
 import DateItem from "./DateItem";
 
 interface ShowListProps {
-  shows: ShowInfo[];
+  eventId: string;
   selectedItem: number | null;
   onSelect: (id: number, name: string, startDate: string) => void;
+  onReservationType: (reservationType: string) => void;
 }
 
 const ShowList = (props: ShowListProps) => {
-  const { shows, selectedItem, onSelect } = props;
+  const { eventId, selectedItem, onSelect, onReservationType } = props;
+
+  const { data } = useQueryShowList(eventId);
+  const { reservationUserType, shows } = data;
+
+  useEffect(() => {
+    onReservationType(reservationUserType);
+  }, [reservationUserType, onReservationType]);
 
   return (
     <div className="flex flex-col gap-4 px-[22px]">

--- a/apps/user/src/pages/buy-ticket/_components/ShowList.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/ShowList.tsx
@@ -1,20 +1,19 @@
-import { useQueryShowList } from "@/hooks/queries/useQueryShowList";
+import { ShowInfo } from "@/types/showType";
 
 import DateItem from "./DateItem";
 
 interface ShowListProps {
-  eventId: string;
+  shows: ShowInfo[];
   selectedItem: number | null;
   onSelect: (id: number, name: string, startDate: string) => void;
 }
 
 const ShowList = (props: ShowListProps) => {
-  const { eventId, selectedItem, onSelect } = props;
-  const { data: showList } = useQueryShowList(eventId);
+  const { shows, selectedItem, onSelect } = props;
 
   return (
     <div className="flex flex-col gap-4 px-[22px]">
-      {showList.map(
+      {shows.map(
         ({ id, name, startDate, endDate, ticketingDate, totalTicketCount }) => (
           <DateItem
             key={id}

--- a/apps/user/src/pages/buy-ticket/_components/TicketContainer.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/TicketContainer.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@uket/ui/lib/utils";
+
+interface TicketContainerProps {
+  children: React.ReactNode;
+  isDisabled: boolean;
+  isSoldOut: boolean;
+  onSelect: () => void;
+}
+
+const TicketContainer = (props: TicketContainerProps) => {
+  const { children, isDisabled, isSoldOut, onSelect } = props;
+
+  return (
+    <div
+      className={cn(
+        "z-40 flex w-full flex-col gap-[9px] rounded-lg bg-white px-5 pb-[15px] pt-[17px] shadow-lg",
+        (isDisabled || isSoldOut) &&
+          "pointer-events-none bg-[#D9D9D9] opacity-60",
+      )}
+      onClick={onSelect}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default TicketContainer;

--- a/apps/user/src/pages/buy-ticket/_components/TicketDivider.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/TicketDivider.tsx
@@ -1,0 +1,5 @@
+const TicketDivider = () => {
+  return <div className="my-[1%] w-full border-[0.5px] border-[#CCCCCC]"></div>;
+};
+
+export default TicketDivider;

--- a/apps/user/src/pages/buy-ticket/_components/TicketFooter.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/TicketFooter.tsx
@@ -1,0 +1,14 @@
+export interface TicketFooterProps
+  extends React.HTMLAttributes<HTMLDivElement> {}
+
+const TicketFooter = (props: TicketFooterProps) => {
+  const { className, children, ...rest } = props;
+
+  return (
+    <div className={`flex gap-10 text-xs ${className}`} {...rest}>
+      {children}
+    </div>
+  );
+};
+
+export default TicketFooter;

--- a/apps/user/src/pages/buy-ticket/_components/TicketHeader.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/TicketHeader.tsx
@@ -1,0 +1,22 @@
+import CircleButton from "./CircleButton";
+
+interface TicketHeaderProps {
+  title: string;
+  isSelected: boolean;
+  fontStyle: string;
+}
+
+const TicketHeader = (props: TicketHeaderProps) => {
+  const { title, isSelected, fontStyle } = props;
+
+  return (
+    <div className="flex justify-between">
+      <div className={fontStyle}>{title}</div>
+      <div className="self-center">
+        <CircleButton isSelected={isSelected} />
+      </div>
+    </div>
+  );
+};
+
+export default TicketHeader;

--- a/apps/user/src/pages/buy-ticket/_components/TimeActivity.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/TimeActivity.tsx
@@ -1,11 +1,9 @@
 import { useSearchParams } from "react-router-dom";
-import { Suspense } from "react";
 import { ActivityComponentType } from "@stackflow/react";
 import { AppScreen } from "@stackflow/plugin-basic-ui";
 
-import RetryErrorBoundary from "@/components/error/RetryErrorBoundary";
-
 import useItemSelect from "@/hooks/useItemSelect";
+import { useQueryReservationList } from "@/hooks/queries/useQueryReservationList";
 
 import SelectTicketItem from "./SelectTicketItem";
 import ReservationList from "./ReservationList";
@@ -21,10 +19,11 @@ import {
 
 interface TimeParams extends ActivityParams {
   showDate: string;
+  reservationUserType: string;
 }
 
 const TimeActivity: ActivityComponentType<TimeParams> = ({ params }) => {
-  const { form, showDate } = params;
+  const { form, showDate, reservationUserType } = params;
 
   const { selectedItem, handleSelectItem } = useItemSelect();
 
@@ -37,10 +36,19 @@ const TimeActivity: ActivityComponentType<TimeParams> = ({ params }) => {
     form.setValue("reservationId", id);
   };
 
+  const { data: reservationList } = useQueryReservationList(
+    showId,
+    reservationUserType,
+  );
+
   return (
     <AppScreen appBar={{ border: false, height: "56px" }}>
       <Activity>
         <ActivityContent>
+          <div className="flex gap-5 px-[22px]">
+            <div>{univName}</div>
+            <div>{reservationUserType}</div>
+          </div>
           <div className="flex gap-3 px-[22px] pb-4">
             <SelectTicketItem title="선택 학교" content={univName!} />
             <SelectTicketItem title="선택 날짜" content={showDate} />
@@ -49,23 +57,19 @@ const TimeActivity: ActivityComponentType<TimeParams> = ({ params }) => {
             <HeaderItem step={"02"} content={"예매 시간을 선택해 주세요."} />
           </ActivityHeader>
 
-          <RetryErrorBoundary>
-            <Suspense>
-              <ReservationList
-                showId={showId}
-                selectedItem={selectedItem}
-                onSelect={handleSelectReservation}
-              />
-              <ActivityFooter>
-                <NextButton
-                  type="submit"
-                  activityName={"CompleteActivity" as never}
-                  disabled={selectedItem === null}
-                  params={{ form }}
-                ></NextButton>
-              </ActivityFooter>
-            </Suspense>
-          </RetryErrorBoundary>
+          <ReservationList
+            reservationList={reservationList}
+            selectedItem={selectedItem}
+            onSelect={handleSelectReservation}
+          />
+          <ActivityFooter>
+            <NextButton
+              type="submit"
+              activityName={"CompleteActivity" as never}
+              disabled={selectedItem === null}
+              params={{ form }}
+            ></NextButton>
+          </ActivityFooter>
         </ActivityContent>
       </Activity>
     </AppScreen>

--- a/apps/user/src/pages/buy-ticket/_components/TimeActivity.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/TimeActivity.tsx
@@ -2,10 +2,12 @@ import { useSearchParams } from "react-router-dom";
 import { ActivityComponentType } from "@stackflow/react";
 import { AppScreen } from "@stackflow/plugin-basic-ui";
 
+import { useReservationSelection } from "@/hooks/useReservationSelection";
 import useItemSelect from "@/hooks/useItemSelect";
+import { useFormatTime } from "@/hooks/useFormatTime";
 import { useQueryReservationList } from "@/hooks/queries/useQueryReservationList";
 
-import SelectTicketItem from "./SelectTicketItem";
+import SelectHeader from "./SelectHeader";
 import ReservationList from "./ReservationList";
 import NextButton from "./NextButton";
 import HeaderItem from "./HeaderItem";
@@ -31,9 +33,22 @@ const TimeActivity: ActivityComponentType<TimeParams> = ({ params }) => {
   const univName = searchParams.get("univName");
   const showId = searchParams.get("showId") as string;
 
-  const handleSelectReservation = (id: number) => {
+  const {
+    selectedStartTime,
+    setSelectedStartTme,
+    selectedEndTime,
+    setSelectedEndTme,
+  } = useReservationSelection();
+
+  const handleSelectReservation = (
+    id: number,
+    startTime: string,
+    endTime: string,
+  ) => {
     handleSelectItem(id);
     form.setValue("reservationId", id);
+    setSelectedStartTme(startTime);
+    setSelectedEndTme(endTime);
   };
 
   const { data: reservationList } = useQueryReservationList(
@@ -41,18 +56,22 @@ const TimeActivity: ActivityComponentType<TimeParams> = ({ params }) => {
     reservationUserType,
   );
 
+  const { formatTime: formatStartTime } = useFormatTime(selectedStartTime);
+  const { formatTime: formatEndTime } = useFormatTime(selectedEndTime);
+  const formatSelectTime =
+    selectedStartTime !== "" ? `${formatStartTime} ~ ${formatEndTime}` : "";
+
   return (
     <AppScreen appBar={{ border: false, height: "56px" }}>
       <Activity>
         <ActivityContent>
-          <div className="flex gap-5 px-[22px]">
-            <div>{univName}</div>
-            <div>{reservationUserType}</div>
-          </div>
-          <div className="flex gap-3 px-[22px] pb-4">
-            <SelectTicketItem title="선택 학교" content={univName!} />
-            <SelectTicketItem title="선택 날짜" content={showDate} />
-          </div>
+          <SelectHeader
+            univName={univName}
+            reservationUserType={reservationUserType}
+            formatShowDate={showDate}
+            formatSelectTime={formatSelectTime}
+          />
+
           <ActivityHeader className="px-[22px]">
             <HeaderItem step={"02"} content={"예매 시간을 선택해 주세요."} />
           </ActivityHeader>

--- a/apps/user/src/pages/buy-ticket/_components/TimeActivity.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/TimeActivity.tsx
@@ -3,7 +3,6 @@ import { ActivityComponentType } from "@stackflow/react";
 import { AppScreen } from "@stackflow/plugin-basic-ui";
 
 import { useReservationSelection } from "@/hooks/useReservationSelection";
-import useItemSelect from "@/hooks/useItemSelect";
 import { useFormatTime } from "@/hooks/useFormatTime";
 import { useQueryReservationList } from "@/hooks/queries/useQueryReservationList";
 
@@ -27,29 +26,16 @@ interface TimeParams extends ActivityParams {
 const TimeActivity: ActivityComponentType<TimeParams> = ({ params }) => {
   const { form, showDate, reservationUserType } = params;
 
-  const { selectedItem, handleSelectItem } = useItemSelect();
-
   const [searchParams] = useSearchParams();
   const univName = searchParams.get("univName");
   const showId = searchParams.get("showId") as string;
 
   const {
+    selectedItem,
     selectedStartTime,
-    setSelectedStartTme,
     selectedEndTime,
-    setSelectedEndTme,
-  } = useReservationSelection();
-
-  const handleSelectReservation = (
-    id: number,
-    startTime: string,
-    endTime: string,
-  ) => {
-    handleSelectItem(id);
-    form.setValue("reservationId", id);
-    setSelectedStartTme(startTime);
-    setSelectedEndTme(endTime);
-  };
+    handleSelectReservation,
+  } = useReservationSelection(form);
 
   const { data: reservationList } = useQueryReservationList(
     showId,

--- a/apps/user/src/pages/buy-ticket/_components/TimeItem.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/TimeItem.tsx
@@ -60,9 +60,7 @@ const TimeItem = (props: TimeItemProps) => {
           fontStyle="text-[32px] font-extrabold"
           isSelected={isSelected}
         />
-
         <TicketDivider />
-
         <TicketFooter>
           <TicketQuantityItem
             title="남은 티켓 수량"

--- a/apps/user/src/pages/buy-ticket/_components/TimeItem.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/TimeItem.tsx
@@ -34,7 +34,7 @@ const TimeItem = (props: TimeItemProps) => {
   const leftCount = totalCount - reservedCount;
 
   useEffect(() => {
-    setIsSoldOut(leftCount === 0);
+    setIsSoldOut(leftCount <= 0);
   }, [leftCount]);
 
   useEffect(() => {
@@ -49,7 +49,7 @@ const TimeItem = (props: TimeItemProps) => {
   return (
     <div className="relative">
       {isDisabled && <Overlay message="티켓 예매 가능 시간이 지났습니다." />}
-      {isSoldOut && <Overlay message="SOLDOUT" soldOut />}
+      {isSoldOut && !isDisabled && <Overlay message="SOLDOUT" soldOut />}
       <TicketContainer
         isDisabled={isDisabled}
         isSoldOut={isSoldOut}

--- a/apps/user/src/pages/buy-ticket/_components/TimeItem.tsx
+++ b/apps/user/src/pages/buy-ticket/_components/TimeItem.tsx
@@ -1,7 +1,13 @@
+import { useEffect, useState } from "react";
+
 import { useFormatTime } from "@/hooks/useFormatTime";
 
 import TicketQuantityItem from "./TicketQuantityItem";
-import CircleButton from "./CircleButton";
+import TicketHeader from "./TicketHeader";
+import TicketFooter from "./TicketFooter";
+import TicketDivider from "./TicketDivider";
+import TicketContainer from "./TicketContainer";
+import Overlay from "./Overlay";
 
 interface TimeItemProps {
   startTime: string;
@@ -22,39 +28,54 @@ const TimeItem = (props: TimeItemProps) => {
     onSelect,
   } = props;
 
-  const { formatTime: formatStartTime } = useFormatTime(startTime);
-  const { formatTime: formatEndTime } = useFormatTime(endTime);
+  const [isDisabled, setIsDisabled] = useState(false);
+  const [isSoldOut, setIsSoldOut] = useState(false);
 
   const leftCount = totalCount - reservedCount;
 
+  useEffect(() => {
+    setIsSoldOut(leftCount === 0);
+  }, [leftCount]);
+
+  useEffect(() => {
+    const currentTime = new Date().getTime();
+    const ticketingTime = new Date(startTime).getTime();
+    setIsDisabled(currentTime > ticketingTime);
+  }, [startTime]);
+
+  const { formatTime: formatStartTime } = useFormatTime(startTime);
+  const { formatTime: formatEndTime } = useFormatTime(endTime);
+
   return (
-    <div
-      className="flex w-full flex-col gap-[9px] rounded-lg bg-white px-5 pb-[15px] pt-[17px] shadow-lg"
-      onClick={onSelect}
-    >
-      <div className="flex justify-between">
-        <div className="text-[32px] font-extrabold">
-          {formatStartTime} ~ {formatEndTime}
-        </div>
-        <div className="self-center">
-          <CircleButton isSelected={isSelected} />
-        </div>
-      </div>
-
-      <div className="my-[1%] w-full border-[0.5px] border-[#CCCCCC]"></div>
-
-      <div className="flex gap-10 text-xs">
-        <TicketQuantityItem
-          title="남은 티켓 수량"
-          amount={leftCount}
-          color="FD724F"
+    <div className="relative">
+      {isDisabled && <Overlay message="티켓 예매 가능 시간이 지났습니다." />}
+      {isSoldOut && <Overlay message="SOLDOUT" soldOut />}
+      <TicketContainer
+        isDisabled={isDisabled}
+        isSoldOut={isSoldOut}
+        onSelect={onSelect}
+      >
+        <TicketHeader
+          title={`${formatStartTime} ~ ${formatEndTime}`}
+          fontStyle="text-[32px] font-extrabold"
+          isSelected={isSelected}
         />
-        <TicketQuantityItem
-          title="총 티켓 수량"
-          amount={totalCount}
-          color="5E5E6E"
-        />
-      </div>
+
+        <TicketDivider />
+
+        <TicketFooter>
+          <TicketQuantityItem
+            title="남은 티켓 수량"
+            amount={leftCount}
+            color="FD724F"
+          />
+          <TicketQuantityItem
+            title="총 티켓 수량"
+            amount={totalCount}
+            color="5E5E6E"
+          />
+        </TicketFooter>
+      </TicketContainer>
     </div>
   );
 };

--- a/apps/user/src/pages/buy-ticket/index.tsx
+++ b/apps/user/src/pages/buy-ticket/index.tsx
@@ -1,14 +1,23 @@
+import { FallbackProps } from "react-error-boundary";
 import { Suspense } from "react";
 
+import BuyTicketErrorFallback from "@/components/fallback/BuyTicketErrorFallback";
+import RetryErrorBoundary from "@/components/error/RetryErrorBoundary";
 
 import { Stack } from "@/utils/buyTicketFlow";
 
 const BuyTicket = () => {
   return (
-    <main>
-      <Suspense>
-        <Stack />
-      </Suspense>
+    <main className="flex h-full flex-col items-center justify-center">
+      <RetryErrorBoundary
+        fallbackComponent={(props: FallbackProps) => (
+          <BuyTicketErrorFallback {...props} />
+        )}
+      >
+        <Suspense>
+          <Stack />
+        </Suspense>
+      </RetryErrorBoundary>
     </main>
   );
 };

--- a/apps/user/src/pages/buy-ticket/index.tsx
+++ b/apps/user/src/pages/buy-ticket/index.tsx
@@ -1,23 +1,13 @@
-import { FallbackProps } from "react-error-boundary";
 import { Suspense } from "react";
-
-import BuyTicketErrorFallback from "@/components/fallback/BuyTicketErrorFallback";
-import RetryErrorBoundary from "@/components/error/RetryErrorBoundary";
 
 import { Stack } from "@/utils/buyTicketFlow";
 
 const BuyTicket = () => {
   return (
     <main className="flex h-full flex-col items-center justify-center">
-      <RetryErrorBoundary
-        fallbackComponent={(props: FallbackProps) => (
-          <BuyTicketErrorFallback {...props} />
-        )}
-      >
-        <Suspense>
-          <Stack />
-        </Suspense>
-      </RetryErrorBoundary>
+      <Suspense>
+        <Stack />
+      </Suspense>
     </main>
   );
 };

--- a/apps/user/src/types/showType.ts
+++ b/apps/user/src/types/showType.ts
@@ -9,6 +9,7 @@ export type ShowInfo = {
 };
 
 export type ShowInfoResponse = {
+  reservationUserType: string;
   universityName: string;
   shows: ShowInfo[];
 };


### PR DESCRIPTION
## 연관된 이슈
> ex) #67

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 티켓 예매 스타일 수정
   - [x] soldout 디자인 추가
   - [x] 티켓 가능 시간대에 따른 디자인 수정
- [x] 변경된 api 수정

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점
- 현재 디자인에 맞춰서 에러 fallback에 로고 이미지를 넣어서 `BuyTicketErrorFallback.tsx`를 추가해봤습니다.
- 티켓 구매 페이지에 공통된 요소가 많아서 추상화를 진행해봤습니다. 더 좋은 방향이 있다면 피드백 남겨주세요!
- 티켓 예매 가능 시각이 아닌 경우의 디자인은 아직 반영되지 않았습니다. 디자인 반영된 후에 추가하겠습니다.

## 💬 리뷰 요구사항(선택)


---
🚨 **이슈를 닫아주세요!**
> ex) close #67
