### PR TITLE
style: 티켓 확인 페이지 및 티켓 상세 모달 스타일 변경

### DIFF
--- a/apps/user/src/components/Indicator.tsx
+++ b/apps/user/src/components/Indicator.tsx
@@ -2,13 +2,21 @@ import React from "react";
 import { VariantProps, cn } from "@uket/ui/lib/utils";
 import { Badge, badgeVariants } from "@uket/ui/components/ui/badge";
 
+import { TicketItem } from "@/types/ticketType";
+
 type BadgeVariant = VariantProps<typeof badgeVariants>["variant"];
 
 interface IndicatorBadge extends React.HTMLAttributes<HTMLDivElement> {
   title: string;
   rounded?: boolean;
-  variant: BadgeVariant;
+  variant: TicketItem["ticketStatus"];
 }
+
+const VARIANT_MAPPING: Record<string, BadgeVariant> = {
+  "입금 확인중": "deposit",
+  "예매 완료": "reservation",
+  "입장 완료": "enter",
+};
 
 const Indicator = (props: IndicatorBadge) => {
   const { title, rounded, variant, className } = props;
@@ -20,7 +28,7 @@ const Indicator = (props: IndicatorBadge) => {
         rounded ? "rounded-lg" : "rounded-md",
         className,
       )}
-      variant={variant}
+      variant={VARIANT_MAPPING[variant] || "default"}
     >
       {title}
     </Badge>

--- a/apps/user/src/components/Nav.tsx
+++ b/apps/user/src/components/Nav.tsx
@@ -19,30 +19,26 @@ const Nav = () => {
   }
 
   return (
-    <>
+    <nav className="container my-2 flex h-10 w-full items-center justify-between self-stretch">
       {["/", "/home"].includes(pathname) ? (
-        <nav className="container my-2 flex h-10 w-full items-center justify-between self-stretch">
-          <Logo />
-          <RetryErrorBoundary
-            resetKeys={["user-info"]}
-            fallbackComponent={(props: FallbackProps) => (
-              <LoginErrorFallback
-                className={cn("text-black", pathname === "/" && "text-white")}
-                {...props}
-              />
-            )}
-          >
-            <Profile />
-          </RetryErrorBoundary>
-        </nav>
+        <Logo />
       ) : (
-        <nav className="my-2 flex h-10 w-full items-center justify-between self-stretch pl-[14px]">
-          <Link to={previousPath}>
-            <IconBack />
-          </Link>
-        </nav>
+        <Link to={previousPath}>
+          <IconBack />
+        </Link>
       )}
-    </>
+      <RetryErrorBoundary
+        resetKeys={["user-info"]}
+        fallbackComponent={(props: FallbackProps) => (
+          <LoginErrorFallback
+            className={cn("text-black", pathname === "/" && "text-white")}
+            {...props}
+          />
+        )}
+      >
+        <Profile />
+      </RetryErrorBoundary>
+    </nav>
   );
 };
 

--- a/apps/user/src/pages/ticket-list/_components/ConfirmModal.tsx
+++ b/apps/user/src/pages/ticket-list/_components/ConfirmModal.tsx
@@ -60,7 +60,7 @@ function ConfirmModal(props: ConfirmModalProps) {
           </section>
           <DialogFooter className="flex-row items-center justify-center gap-3">
             <Button
-              className="basis-1/2 bg-[#ccc]"
+              className="basis-1/2 bg-[#ccc] hover:bg-[#afafaf]"
               onClick={e => {
                 e.stopPropagation();
                 setOpen(false);
@@ -69,7 +69,7 @@ function ConfirmModal(props: ConfirmModalProps) {
               아니오
             </Button>
             <DialogClose asChild>
-              <Button className="basis-1/2 bg-[#FD724F]" onClick={handleCancel}>
+              <Button className="basis-1/2 bg-[#FD724F] hover:bg-[#ff5328]" onClick={handleCancel}>
                 네, 취소할게요.
               </Button>
             </DialogClose>

--- a/apps/user/src/pages/ticket-list/_components/ConfirmModal.tsx
+++ b/apps/user/src/pages/ticket-list/_components/ConfirmModal.tsx
@@ -44,38 +44,38 @@ function ConfirmModal(props: ConfirmModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button
-          variant="link"
-          className="cursor-pointer p-0 text-xs text-[#FD724F] underline"
-          onClick={e => e.stopPropagation()}
-        >
-          예매 취소
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="max-w-60 rounded-2xl sm:max-w-xs" isXHidden>
-        <section className="py-5 sm:py-12">
-          <h1 className="text-center text-sm font-semibold">
-            정말 예매를 취소하시겠어요?
-          </h1>
-        </section>
-        <DialogFooter className="flex-row items-center justify-center gap-3">
-          <Button
-            className="basis-1/2 bg-[#ccc]"
-            onClick={e => {
-              e.stopPropagation();
-              setOpen(false);
-            }}
+      <div onClick={e => e.stopPropagation()}>
+        <DialogTrigger asChild>
+          <div
+            className="cursor-pointer py-3 text-xs text-[#FD724F] underline"
           >
-            아니오
-          </Button>
-          <DialogClose asChild>
-            <Button className="basis-1/2 bg-[#FD724F]" onClick={handleCancel}>
-              네, 취소할게요.
+            예매 취소
+          </div>
+        </DialogTrigger>
+        <DialogContent className="max-w-60 rounded-2xl sm:max-w-xs" isXHidden>
+          <section className="py-5 sm:py-12">
+            <h1 className="text-center text-sm font-semibold">
+              정말 예매를 취소하시겠어요?
+            </h1>
+          </section>
+          <DialogFooter className="flex-row items-center justify-center gap-3">
+            <Button
+              className="basis-1/2 bg-[#ccc]"
+              onClick={e => {
+                e.stopPropagation();
+                setOpen(false);
+              }}
+            >
+              아니오
             </Button>
-          </DialogClose>
-        </DialogFooter>
-      </DialogContent>
+            <DialogClose asChild>
+              <Button className="basis-1/2 bg-[#FD724F]" onClick={handleCancel}>
+                네, 취소할게요.
+              </Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </div>
     </Dialog>
   );
 }

--- a/apps/user/src/pages/ticket-list/_components/ConfirmModal.tsx
+++ b/apps/user/src/pages/ticket-list/_components/ConfirmModal.tsx
@@ -48,26 +48,29 @@ function ConfirmModal(props: ConfirmModalProps) {
         <Button
           variant="link"
           className="cursor-pointer p-0 text-xs text-[#FD724F] underline"
+          onClick={e => e.stopPropagation()}
         >
           예매 취소
         </Button>
       </DialogTrigger>
-      <DialogContent className=" max-w-60 rounded-2xl sm:max-w-xs">
-        <section className="py-6 sm:py-12">
+      <DialogContent className="max-w-60 rounded-2xl sm:max-w-xs" isXHidden>
+        <section className="py-5 sm:py-12">
           <h1 className="text-center text-sm font-semibold">
             정말 예매를 취소하시겠어요?
           </h1>
         </section>
         <DialogFooter className="flex-row items-center justify-center gap-3">
-          <Button className="basis-1/2" onClick={() => setOpen(false)}>
+          <Button
+            className="basis-1/2 bg-[#ccc]"
+            onClick={e => {
+              e.stopPropagation();
+              setOpen(false);
+            }}
+          >
             아니오
           </Button>
           <DialogClose asChild>
-            <Button
-              variant="destructive"
-              className="basis-1/2"
-              onClick={handleCancel}
-            >
+            <Button className="basis-1/2 bg-[#FD724F]" onClick={handleCancel}>
               네, 취소할게요.
             </Button>
           </DialogClose>

--- a/apps/user/src/pages/ticket-list/_components/GridItem.tsx
+++ b/apps/user/src/pages/ticket-list/_components/GridItem.tsx
@@ -13,16 +13,27 @@ const GridItem = (props: GridItemProps) => {
   const { title, content, isTicketNo, isPlace } = props;
   const goToMapLink = `https://map.kakao.com/?q=${content}`;
 
+  const item = isPlace ? (
+    <Link
+      to={isPlace ? goToMapLink : "#"}
+      target="_blank"
+      className="flex items-center font-bold"
+    >
+      {title}
+      {isPlace && <ChevronRightIcon className="h-4 w-4 pt-0.5" />}
+    </Link>
+  ) : (
+    <p className="font-bold">{title}</p>
+  );
+
   return (
-    <div className="space-y-2 text-xs">
-      <Link
-        to={isPlace ? goToMapLink : "#"}
-        target="_blank"
-        className="flex items-center font-bold"
-      >
-        {title}
-        {isPlace && <ChevronRightIcon className="h-4 w-4 pt-0.5" />}
-      </Link>
+    <div
+      className="space-y-2 text-xs"
+      onClick={e => {
+        isPlace && e.stopPropagation();
+      }}
+    >
+      {item}
       <p
         className={cn(
           isTicketNo

--- a/apps/user/src/pages/ticket-list/_components/GridItem.tsx
+++ b/apps/user/src/pages/ticket-list/_components/GridItem.tsx
@@ -1,17 +1,28 @@
+import { Link } from "react-router-dom";
 import { cn } from "@uket/ui/lib/utils";
+import { ChevronRightIcon } from "@uket/ui/components/ui/icon";
 
 interface GridItemProps {
   title: string;
   content: string;
   isTicketNo?: boolean;
+  isPlace?: boolean;
 }
 
 const GridItem = (props: GridItemProps) => {
-  const { title, content, isTicketNo } = props;
+  const { title, content, isTicketNo, isPlace } = props;
+  const goToMapLink = `https://map.kakao.com/?q=${content}`;
 
   return (
     <div className="space-y-2 text-xs">
-      <p className="font-bold">{title}</p>
+      <Link
+        to={isPlace ? goToMapLink : "#"}
+        target="_blank"
+        className="flex items-center font-bold"
+      >
+        {title}
+        {isPlace && <ChevronRightIcon className="h-4 w-4 pt-0.5" />}
+      </Link>
       <p
         className={cn(
           isTicketNo

--- a/apps/user/src/pages/ticket-list/_components/QRCode.tsx
+++ b/apps/user/src/pages/ticket-list/_components/QRCode.tsx
@@ -1,14 +1,13 @@
 import { useMemo } from "react";
 import { Separator } from "@uket/ui/components/ui/separator";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTrigger,
-} from "@uket/ui/components/ui/dialog";
-import { Button } from "@uket/ui/components/ui/button";
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@uket/ui/components/ui/card";
 import { useQueryClient } from "@tanstack/react-query";
 
 import Indicator from "@/components/Indicator";
@@ -48,7 +47,7 @@ const QRCode = (props: QRCodeProps) => {
       enterStartTime: formatDate(item.enterStartTime, "time"),
       enterEndTime: formatDate(item.enterEndTime, "time"),
     };
-  }, [data]);
+  }, [data, id]);
 
   const {
     userName,
@@ -66,39 +65,30 @@ const QRCode = (props: QRCodeProps) => {
   } = ticket;
 
   return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button variant="outline" className="h-24 w-24 border-none p-0">
-          <img
-            src={qrCode}
-            alt="qrcode"
-            width={100}
-            height={100}
-            className="aspect-square object-cover"
-          />
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="max-w-xs rounded-lg sm:max-w-md">
-        <DialogHeader className="gap-3">
+    <Card className="border-none shadow-none">
+      <CardHeader className="gap-3">
+        <CardTitle>
           <div className="text-left">
             <Indicator
-              variant={"darkdeposit"}
+              variant={ticketStatus}
               title={ticketStatus}
               rounded
               className="relative left-0 top-0"
             />
           </div>
-          <DialogDescription className="flex flex-col items-center justify-center">
-            <img
-              src={qrCode}
-              alt="qrcode"
-              width={100}
-              height={100}
-              className="aspect-square h-36 w-36"
-            />
-            <span className="text-xs text-[#7250FD]">{ticketNo}</span>
-          </DialogDescription>
-        </DialogHeader>
+        </CardTitle>
+        <CardDescription className="flex flex-col items-center justify-center">
+          <img
+            src={qrCode}
+            alt="qrcode"
+            width={100}
+            height={100}
+            className="aspect-square h-36 w-36 scale-125"
+          />
+          <span className="z-50 text-xs text-[#7250FD]">{ticketNo}</span>
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
         <section className="flex flex-col gap-3">
           <TicketHeader
             universityName={universityName}
@@ -119,13 +109,13 @@ const QRCode = (props: QRCodeProps) => {
             <ConfirmModal ticketId={id} />
           </footer>
         </section>
-        <DialogFooter className="rounded-lg bg-[#FDC950] py-3 text-center sm:justify-center">
-          <h1 className="text-sm font-bold">
-            학생증 또는 신분증을 제시해 주세요!
-          </h1>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      </CardContent>
+      <CardFooter className="mx-5 mb-3 justify-center rounded-lg bg-[#FDC950] py-3">
+        <h1 className="text-sm font-bold">
+          학생증 또는 신분증을 제시해 주세요!
+        </h1>
+      </CardFooter>
+    </Card>
   );
 };
 export default QRCode;

--- a/apps/user/src/pages/ticket-list/_components/Ticket.tsx
+++ b/apps/user/src/pages/ticket-list/_components/Ticket.tsx
@@ -1,4 +1,9 @@
 import { lazy } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from "@uket/ui/components/ui/dialog";
 import { Card, CardContent } from "@uket/ui/components/ui/card";
 import { AspectRatio } from "@uket/ui/components/ui/aspect-ratio";
 
@@ -37,51 +42,55 @@ const Ticket = (props: TicketProps) => {
   } = props;
 
   return (
-    <Card className="border-none bg-transparent shadow-none">
-      <CardContent className="flex flex-col divide-y divide-dashed p-0">
-        <section className="flex basis-3/4 flex-col overflow-hidden rounded-b-3xl rounded-t-xl bg-white shadow-xl">
-          <header className="relative">
-            <AspectRatio ratio={16 / 9}>
-              <img
-                className="h-full w-full object-cover"
-                src="https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80"
-                alt="ticket"
-              />
-            </AspectRatio>
-            <Indicator
-              variant={"darkdeposit"}
-              title={ticketStatus}
-              rounded
-              className="left-3 top-3"
-            />
-          </header>
-          <main className="container flex grow flex-col justify-around gap-3 py-5">
-            <TicketHeader
-              universityName={universityName}
-              eventName={eventName}
-              showName={showName}
-            />
-            <TicketDetail
-              userName={userName}
-              showDate={showDate}
-              enterTime={`${enterStartTime} ~ ${enterEndTime}`}
-              showLocation={showLocation}
-            />
-          </main>
-        </section>
-        <footer className="flex basis-1/4 justify-around rounded-b-xl rounded-t-3xl bg-white pb-2 pl-3 pt-5 shadow-md">
-          <aside className="flex flex-col items-start justify-between">
-            <div className="w-32 truncate">
-              <GridItem title="일련번호" content={ticketNo} isTicketNo />
-            </div>
-            <ConfirmModal ticketId={ticketId} />
-          </aside>
-          <aside>
-            <QRCode qrCode={qrCode} id={ticketId} />
-          </aside>
-        </footer>
-      </CardContent>
-    </Card>
+    <Dialog>
+      <DialogTrigger className="text-start">
+        <Card className="border-none bg-transparent shadow-none">
+          <CardContent className="flex flex-col divide-y divide-dashed p-0">
+            <section className="flex basis-3/4 flex-col overflow-hidden rounded-b-3xl rounded-t-xl bg-white shadow-xl">
+              <header className="relative">
+                <AspectRatio ratio={16 / 9}>
+                  <img
+                    className="h-full w-full object-cover"
+                    src="https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80"
+                    alt="ticket"
+                  />
+                </AspectRatio>
+                <Indicator
+                  variant={ticketStatus}
+                  title={ticketStatus}
+                  rounded
+                  className="left-3 top-3"
+                />
+              </header>
+              <main className="container flex grow flex-col justify-around gap-3 py-5">
+                <TicketHeader
+                  universityName={universityName}
+                  eventName={eventName}
+                  showName={showName}
+                />
+                <TicketDetail
+                  userName={userName}
+                  showDate={showDate}
+                  enterTime={`${enterStartTime} ~ ${enterEndTime}`}
+                  showLocation={showLocation}
+                />
+              </main>
+            </section>
+            <footer className="flex basis-1/4 rounded-b-xl rounded-t-3xl bg-white pb-2 pl-7 pt-5 shadow-md">
+              <aside className="flex flex-col items-start justify-between">
+                <div className="w-32 truncate">
+                  <GridItem title="일련번호" content={ticketNo} isTicketNo />
+                </div>
+                <ConfirmModal ticketId={ticketId} />
+              </aside>
+            </footer>
+          </CardContent>
+        </Card>
+      </DialogTrigger>
+      <DialogContent className="max-w-xs rounded-lg p-0 sm:max-w-md">
+        <QRCode qrCode={qrCode} id={ticketId} />
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/apps/user/src/pages/ticket-list/_components/TicketDetail.tsx
+++ b/apps/user/src/pages/ticket-list/_components/TicketDetail.tsx
@@ -17,7 +17,7 @@ const TicketDetail = (props: TicketDetailProps) => {
     <section className="grid auto-rows-auto grid-cols-2 gap-4">
       <GridItem title={"예매자"} content={userName} />
       <GridItem title={"입장 날짜"} content={showDate} />
-      <GridItem title={"위치(공연장)"} content={showLocation} />
+      <GridItem title={"위치(공연장)"} content={showLocation} isPlace />
       <GridItem title={"입장 시간"} content={enterTime} />
       {createdAt && userType && (
         <>

--- a/apps/user/src/pages/ticket-list/index.tsx
+++ b/apps/user/src/pages/ticket-list/index.tsx
@@ -9,8 +9,11 @@ const TicketListPage = () => {
   return (
     <main className="relative flex h-full flex-col items-center justify-evenly bg-[#F2F2F2]">
       <main className="mb-10 mt-6 flex h-full w-full flex-col gap-4">
-        <header className="container text-xl font-bold">
+        <header className="container flex items-center justify-between text-xl font-bold">
           <p>내 티켓</p>
+          <p className="text-brand border-brand bg-brand/10 w-fit rounded-md border-[0.5px] px-2 py-1 text-xs">
+            티켓을 터치하여 QR 제시
+          </p>
         </header>
         <section className="flex w-full justify-center py-10 lg:container">
           <RetryErrorBoundary>

--- a/apps/user/src/types/ticketType.ts
+++ b/apps/user/src/types/ticketType.ts
@@ -5,7 +5,7 @@ export type TicketItem = {
   enterEndTime: string;
   showLocation: string;
   universityName: string;
-  ticketStatus: string;
+  ticketStatus: "입금 확인중" | "예매 완료" | "입장 완료";
   ticketNo: string;
   userType: string;
   showName: string;

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -16,12 +16,12 @@ const badgeVariants = cva(
           "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/80",
         outline: "text-slate-950 dark:text-slate-50",
         banner: "border-transparent bg-[#f2f2f2c1] text-[#5E5E6E]",
-        reservation: "border-transparent bg-[#17171B] text-[#81B0FE]",
-        enter: "border-transparent bg-[#ffffff] text-[#9981FE]",
-        deposit: "border-transparent bg-[#5E5E6E] text-[#FFEF60]",
-        darkreservation: "border-transparent bg-[#81B0FE] text-[#17171B]",
-        darkenter: "border-transparent bg-[#9981FE] text-[#ffffff]",
-        darkdeposit: "border-transparent bg-[#FDD881] text-[#5E5E6E]",
+        reservation:
+          "border-transparent bg-[#17171B] text-[#81B0FE] w-22 gap-1 items-center after:content-[''] after:w-2 after:h-2 after:bg-[#81B0FE] after:rounded-full",
+        enter:
+          "border-transparent bg-[#ffffff] text-[#9981FE] w-22 gap-1 items-center after:content-[''] after:w-2 after:h-2 after:bg-[#9981FE] after:rounded-full",
+        deposit:
+          "border-transparent bg-[#5E5E6E] text-[#FFEF60] w-22 gap-1 items-center after:content-[''] after:w-2 after:h-2 after:bg-[#FFEF60] after:rounded-full",
       },
     },
     defaultVariants: {

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -28,10 +28,15 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+interface DialogContentCloseProps {
+  isXHidden?: boolean;
+}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> &
+    DialogContentCloseProps
+>(({ className, children, isXHidden = false, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -44,7 +49,7 @@ const DialogContent = React.forwardRef<
     >
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-slate-100 data-[state=open]:text-slate-500 dark:ring-offset-slate-950 dark:focus:ring-slate-300 dark:data-[state=open]:bg-slate-800 dark:data-[state=open]:text-slate-400">
-        <X className="h-4 w-4" />
+        <X className={cn(isXHidden && "hidden", "h-4 w-4")} />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>

--- a/packages/ui/src/components/ui/icon.tsx
+++ b/packages/ui/src/components/ui/icon.tsx
@@ -7,4 +7,5 @@ export {
   SwitchCameraIcon,
   ScanIcon,
   LoaderCircleIcon,
+  ChevronRightIcon,
 } from "lucide-react";


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호

issue #69 
## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 내 티켓 확인 페이지 스타일 변경
- [x] 티켓, 티켓 상세 모달, 티켓 취소 모달 스타일 변경 
## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점

- 피그마 디자인에 맞게 스타일을 일부 수정했습니다.
- 티켓의 예매 취소 버튼 클릭 후, 모달 오버레이 클릭 시 티켓 상세 모달이 띄워지는 버그가 생겼습니다. (기존에는 예매 취소 모달만 사라져야 합니다.) 해결하지 못하여, 티켓의 예매 취소 버튼을 삭제해야 하는 방향을 고려해봐야 할 것 같습니다.(티켓 상세 모달의 예매 취소 하나만 가져가도록) 기획과 얘기해봐야 할 것 같습니다.

https://github.com/DCNJ-Uket/Uket-FE/assets/101445377/d95f6f2d-25ba-46b0-8825-f9af29ed5514

## 💬 리뷰 요구사항(선택)

---
🚨 **이슈를 닫아주세요!**
> ex) close #이슈번호

close #69 