### PR TITLE
refactor: 회원가입 및 로그인 페이지 스타일 수정

### DIFF
--- a/apps/user/src/components/Nav.tsx
+++ b/apps/user/src/components/Nav.tsx
@@ -28,7 +28,7 @@ const Nav = () => {
         </Link>
       )}
 
-      {["/buy-ticket", "/myinfo"].includes(pathname) ? null : (
+      {["/buy-ticket", "/myinfo", "/login"].includes(pathname) ? null : (
         <RetryErrorBoundary
           resetKeys={["user-info"]}
           fallbackComponent={(props: FallbackProps) => (

--- a/apps/user/src/pages/login/index.tsx
+++ b/apps/user/src/pages/login/index.tsx
@@ -6,7 +6,7 @@ import { GOOGLE_LOGIN_URL, KAKAO_LOGIN_URL } from "@/constants/auth_url";
 const LoginPage = () => {
   return (
     <main className="flex h-full flex-col items-center justify-evenly">
-      <main className="container flex h-full w-full flex-col justify-evenly">
+      <main className="container mt-6 mb-10 flex h-full w-full flex-col justify-between">
         <section className="flex w-full flex-col items-center gap-4">
           <h1 className="w-full text-2xl font-black">
             <p>학교 축제 티켓을</p>

--- a/apps/user/src/pages/signup/_components/UserTypeActivity.tsx
+++ b/apps/user/src/pages/signup/_components/UserTypeActivity.tsx
@@ -7,9 +7,7 @@ import {
   FormMessage,
 } from "@uket/ui/components/ui/form";
 import { ActivityComponentType } from "@stackflow/react";
-import { AppScreen } from "@stackflow/plugin-basic-ui";
-
-import Logo from "@/components/Logo";
+import { AppScreen, IconBack } from "@stackflow/plugin-basic-ui";
 
 import { validateForm } from "../../../utils/vaildateForm";
 import { useStackForm } from "../../../hooks/useStackForm";
@@ -22,6 +20,8 @@ import {
   ActivityHeader,
 } from "./Activity";
 
+import { Link } from "@/router";
+
 const UserTypeActivity: ActivityComponentType = () => {
   const { form } = useStackForm();
 
@@ -29,7 +29,11 @@ const UserTypeActivity: ActivityComponentType = () => {
     <AppScreen
       appBar={{
         border: false,
-        renderLeft: () => <Logo onActivity />,
+        renderLeft: () => (
+          <Link to={"/login"} className="px-1.5">
+            <IconBack />
+          </Link>
+        ),
       }}
     >
       <Activity>


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호

issue #82 

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 로그인 페이지 스타일 수정(피그마 디자인 반영)
- [x] 로그인 페이지의 우측 상단에 프로필이 렌더링되는 문제 수정
- [x] 회원가입의 유저 타입 선택 플로우에서 상단의 로고를 제거하고 뒤로가기 버튼으로 대체

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점

## 💬 리뷰 요구사항(선택)


---
🚨 **이슈를 닫아주세요!**
> ex) close #이슈번호

close #82 
