### PR TITLE
feat: 로그인 유도 모달 리다이렉트 경로 수정

### DIFF
--- a/apps/user/src/hooks/mutations/useMutationLogin.ts
+++ b/apps/user/src/hooks/mutations/useMutationLogin.ts
@@ -3,7 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { AuthResponse, LoginRequestParams } from "@/types/authType";
 
 import { setAccessToken } from "@/utils/handleToken";
-import { setRefreshToken } from "@/utils/handleCookie";
+import { deleteCookie, getCookie, setRefreshToken } from "@/utils/handleCookie";
 
 import { useNavigate } from "@/router";
 import { login } from "@/api/auth";
@@ -19,9 +19,21 @@ export const useMutationLogin = () => {
       setRefreshToken("refreshToken", refreshToken);
 
       if (isRegistered) {
-        navigate("/", {
-          replace: true,
-        });
+        const login_redirect_url = getCookie("login_redirect_url");
+        if (login_redirect_url) {
+          deleteCookie("login_redirect_url", {
+            path: "/",
+          });
+
+          navigate(login_redirect_url, {
+            replace: true,
+          });
+          return;
+        } else {
+          navigate("/", {
+            replace: true,
+          });
+        }
       } else {
         navigate("/signup", {
           state: { isUnRegistered: true },

--- a/apps/user/src/hooks/useControlRedirect.ts
+++ b/apps/user/src/hooks/useControlRedirect.ts
@@ -1,7 +1,8 @@
+import { useLocation } from "react-router-dom";
 import { useState } from "react";
 
 import { getAccessToken } from "@/utils/handleToken";
-import { getRefreshToken } from "@/utils/handleCookie";
+import { getRefreshToken, setCookie } from "@/utils/handleCookie";
 
 import { Path, useNavigate } from "@/router";
 
@@ -13,7 +14,7 @@ interface RedirectAndModalPath {
 export const useControlRedirect = () => {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
-
+  const { pathname, search } = useLocation();
   const handleOpenModalOrRedirect = ({
     path,
     onCustomClick,
@@ -35,6 +36,7 @@ export const useControlRedirect = () => {
 
   const handleRedirectToLogin = () => {
     handleCloseModal();
+    setCookie('login_redirect_url', pathname + search)
     navigate("/login");
   };
 

--- a/apps/user/src/utils/handleCookie.ts
+++ b/apps/user/src/utils/handleCookie.ts
@@ -13,6 +13,27 @@ export interface CookieSetOptions {
 
 const cookies = new Cookies();
 
+export const setCookie = (
+  name: string,
+  value: string,
+  options?: CookieSetOptions,
+) => {
+  const defaultOptions: CookieSetOptions = {
+    maxAge: 60 * 60 * 2,
+    path: "/",
+  };
+
+  cookies.set(name, value, { ...defaultOptions, ...options });
+};
+
+export const getCookie = (name: string) => {
+  return cookies.get(name);
+};
+
+export const deleteCookie = (name: string, options?: CookieSetOptions) => {
+  cookies.remove(name, { ...options });
+};
+
 export const setRefreshToken = (
   name: string,
   value: string,


### PR DESCRIPTION
- 로그인 시, 로그인 유도 모달을 연 페이지로 이동하도록 수정했습니다.

## 연관된 이슈
> ex) #이슈번호
issue #101 

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 로그인 유도 모달로 로그인 시, 리다이렉트 경로 수정
  - `cookie`를 사용하여, 로그인 모달을 연 시점의 페이지 경로를 저장하고 로그인을 완료하면 해당 경로로 리다이렉트하면서 저장한 쿠키를 삭제합니다.


## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점

기존에는 로그인 유도 모달로 로그인 시, 항상 루트(`/`)경로로 리다이렉트 되었습니다.
축제 정보 확인 페이지에서 로그인 유도 모달로 로그인 시, 모달을 연 페이지로 리다이렉트 되는 것이 UX 측면에서 좋을 것이라고 판단해 리다이렉트 경로를 수정했습니다.

현재 로그인 유도 모달은, 루트 경로와 축제 정보 확인 페이지에서 사용됩니다.
축제 정보 확인 페이지의 경우 선택한 대학과 관련된 `params`가 존재합니다. 
해당 대학이 만약 로그인을 완료한 시점에 더 이상 축제 정보를 제공하지 않는다면, 리다이렉트 되었을 때 API 오류가 발생합니다.
이를 고려한다면, 현재 PR의 기능이 적절하지 않을 수 있으나 상단 로고 또는 대학교 선택 `Selector`를 활용하여 충분히 에러를 초기화할 수 있다는 점에서 이점이 더 클 것으로 예상됩니다.

## 💬 리뷰 요구사항(선택)


---
🚨 **이슈를 닫아주세요!**
> ex) close #이슈번호
close #101 
