### PR TITLE
[feat] 회원탈퇴 api 연결

### DIFF
--- a/apps/soritor/src/api/instance.ts
+++ b/apps/soritor/src/api/instance.ts
@@ -15,6 +15,7 @@ const SERVER_VERSION = "/api/v1";
 const AUTH_REQUIRED_PATH = [
   "/users/register",
   "/users/info",
+  "/users/delete",
   "/tickets",
   "/users/tickets",
   "/tickets/:id/cancel",

--- a/apps/soritor/src/api/user.ts
+++ b/apps/soritor/src/api/user.ts
@@ -1,4 +1,8 @@
-import { UserInfoResponse, UserInfoUpdateRequest } from "@/types/userType";
+import {
+  UserInfoResponse,
+  UserInfoUpdateRequest,
+  DeleteUserResponse,
+} from "@/types/userType";
 
 import { instance } from "./instance";
 
@@ -16,6 +20,12 @@ export const updateUserInfo = async ({
     depositorName,
     phoneNumber,
   });
+
+  return data;
+};
+
+export const deleteUserInfo = async () => {
+  const { data } = await instance.post<DeleteUserResponse>("/users/delete");
 
   return data;
 };

--- a/apps/soritor/src/hooks/mutations/useMutationDeleteUser.ts
+++ b/apps/soritor/src/hooks/mutations/useMutationDeleteUser.ts
@@ -14,7 +14,7 @@ export const useMutationDeleteUser = () => {
   const mutation = useMutation({
     mutationFn: () => deleteUserInfo(),
     onSuccess: (data: DeleteUserResponse) => {
-      queryClient.invalidateQueries({ queryKey: ["user-info"] });
+      queryClient.removeQueries({ queryKey: ["user-info"] });
 
       clearRefreshToken("refreshToken");
       clearAccessToken("accessToken");

--- a/apps/soritor/src/hooks/mutations/useMutationDeleteUser.ts
+++ b/apps/soritor/src/hooks/mutations/useMutationDeleteUser.ts
@@ -1,0 +1,27 @@
+import { useMutation } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { deleteUserInfo } from "@/api/user";
+
+import { DeleteUserResponse } from "@/types/userType";
+
+import { clearAccessToken } from "@/utils/handleToken";
+import { clearRefreshToken } from "@/utils/handleCookie";
+
+export const useMutationDeleteUser = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: () => deleteUserInfo(),
+    onSuccess: (data: DeleteUserResponse) => {
+      queryClient.invalidateQueries({ queryKey: ["user-info"] });
+
+      clearRefreshToken("refreshToken");
+      clearAccessToken("accessToken");
+
+      return data;
+    },
+  });
+
+  return mutation;
+};

--- a/apps/soritor/src/pages/myinfo/_components/DeleteUserInfoModal.tsx
+++ b/apps/soritor/src/pages/myinfo/_components/DeleteUserInfoModal.tsx
@@ -11,38 +11,52 @@ import { Button } from "@uket/ui/components/ui/button";
 
 import { useNavigate } from "@/router";
 
-import { clearAccessToken } from "@/utils/handleToken";
-import { clearRefreshToken } from "@/utils/handleCookie";
+import { useMutationDeleteUser } from "@/hooks/mutations/useMutationDeleteUser";
 
-const LogoutModal = () => {
+const DeleteUserInfoModal = () => {
   const { toast } = useToast();
 
   const [open, setOpen] = useState(false);
 
   const navigate = useNavigate();
 
-  const handleLogout = () => {
-    clearRefreshToken("refreshToken");
-    clearAccessToken("accessToken");
+  const mutation = useMutationDeleteUser();
+
+  const handleDeleteUserInfo = () => {
     setOpen(false);
-    toast({
-      title: "로그아웃 성공!",
+    mutation.mutate(undefined, {
+      onSuccess: () => {
+        toast({
+          title: "회원탈퇴 성공!",
+        });
+        navigate("/", { replace: true });
+      },
+      onError: () => {
+        toast({
+          title: "회원탈퇴 실패",
+        });
+      },
     });
-    navigate("/", { replace: true });
   };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button className="hover:bg-brandHover basis-1/2 rounded-lg bg-[#8989A1] text-[#F2F2F2]">
-          로그아웃
+        <Button
+          variant="outline"
+          className="basis-1/2 rounded-lg border border-[#8989A1] text-[#8989A1]"
+        >
+          회원 탈퇴
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-72 rounded-2xl sm:max-w-xs" isXHidden>
-        <section className="pb-3 pt-5 sm:py-10">
+        <section className="flex flex-col gap-1 pb-3 pt-5 sm:py-10">
           <h1 className="text-center text-sm font-semibold">
-            로그아웃 하시겠습니까?
+            회원 탈퇴 하시겠습니까?
           </h1>
+          <h3 className="text-desc text-center text-xs font-medium">
+            계정정보가 바로 삭제되며 복구할 수 없습니다.
+          </h3>
         </section>
         <DialogFooter className="flex-row items-center justify-center gap-3">
           <Button
@@ -55,7 +69,7 @@ const LogoutModal = () => {
           <DialogClose asChild>
             <Button
               className="basis-1/2 bg-[#FD724F] text-xs"
-              onClick={handleLogout}
+              onClick={handleDeleteUserInfo}
             >
               네
             </Button>
@@ -66,4 +80,4 @@ const LogoutModal = () => {
   );
 };
 
-export default LogoutModal;
+export default DeleteUserInfoModal;

--- a/apps/soritor/src/pages/myinfo/_components/DeleteUserInfoModal.tsx
+++ b/apps/soritor/src/pages/myinfo/_components/DeleteUserInfoModal.tsx
@@ -34,6 +34,7 @@ const DeleteUserInfoModal = () => {
       onError: () => {
         toast({
           title: "회원탈퇴 실패",
+          variant: "brandDestructive",
         });
       },
     });

--- a/apps/soritor/src/pages/myinfo/index.tsx
+++ b/apps/soritor/src/pages/myinfo/index.tsx
@@ -1,19 +1,11 @@
-import { Button } from "@uket/ui/components/ui/button";
+import DeleteUserInfoModal from "@/pages/myinfo/_components/DeleteUserInfoModal";
 
 import RetryErrorBoundary from "@/components/error/RetryErrorBoundary";
-
-import { clearAccessToken } from "@/utils/handleToken";
-import { clearRefreshToken } from "@/utils/handleCookie";
 
 import UserInfoSection from "./_components/UserInfoSection";
 import LogoutModal from "./_components/LogoutModal";
 
 const MyInfo = () => {
-  const logout = () => {
-    clearRefreshToken("refreshToken");
-    clearAccessToken("accessToken");
-  };
-
   return (
     <main className="relative flex h-full flex-col items-center bg-[#F2F2F2]">
       <main className="flex h-full w-full flex-col gap-3 pb-10">
@@ -21,13 +13,8 @@ const MyInfo = () => {
           <UserInfoSection />
         </RetryErrorBoundary>
         <div className="mt-5 flex items-center gap-4 px-5">
-          <Button
-            variant="outline"
-            className="basis-1/2 rounded-lg border border-[#8989A1] text-[#8989A1]"
-          >
-            회원 탈퇴
-          </Button>
-          <LogoutModal onLogout={logout} />
+          <DeleteUserInfoModal />
+          <LogoutModal />
         </div>
       </main>
     </main>

--- a/apps/soritor/src/types/userType.ts
+++ b/apps/soritor/src/types/userType.ts
@@ -14,3 +14,8 @@ export type UserInfoUpdateRequest = {
   depositorName: string;
   phoneNumber: string;
 };
+
+export type DeleteUserResponse = {
+  userId: number;
+  name: string;
+};

--- a/packages/ui/src/components/ui/toast.tsx
+++ b/packages/ui/src/components/ui/toast.tsx
@@ -36,6 +36,8 @@ const toastVariants = cva(
           "destructive group border-red-500 bg-red-500 text-slate-50 dark:border-red-900 dark:bg-red-900 dark:text-slate-50",
         brand:
           "border-[#9A81FD] bg-[#9A81FD] text-[13px] text-white rounded-2xl flex justify-center h-11",
+        brandDestructive:
+          "border-[#FD724F] bg-[#FD724F] text-[13px] text-white rounded-2xl flex justify-center h-11",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## 연관된 이슈
> ex) #126

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 회원탈퇴 api 연결
- [x] 기존 로그아웃 모달 세부 로직 및 디자인 수정

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점

## 💬 리뷰 요구사항(선택)
- 현재 디자인에는 회원탈퇴 완료 후에 `#FD724F`색상의 토스트 메세지가 뜨게 되어있습니다. 제 판단으로 저희 서비스의 대표 색상인 `#724FFD`를 회원탈퇴 완료에, `#FD724F`를 회원탈퇴 실패 시에 사용하는 게 맞다고 판단하여 임의로 수정해놨습니다. 의견 있으시면 편하게 말씀해주세요!


---
🚨 **이슈를 닫아주세요!**
> ex) close #126 
