### PR TITLE
[feat] 티켓 예매 완료 화면의 계좌 정보 조회 api 연결

### DIFF
--- a/apps/soritor/src/hooks/mutations/useMutationBuyTicket.ts
+++ b/apps/soritor/src/hooks/mutations/useMutationBuyTicket.ts
@@ -7,8 +7,6 @@ import { TicketResponse } from "@/types/showType";
 
 import { FormSchemaType } from "../useTicketStackForm";
 
-
-
 export const useMutationBuyTicket = () => {
   const queryClient = useQueryClient();
 
@@ -16,7 +14,7 @@ export const useMutationBuyTicket = () => {
     mutationFn: (data: FormSchemaType) => buyTicket(data),
     onSuccess: (data: TicketResponse) => {
       queryClient.invalidateQueries({ queryKey: ["my-ticket-list"] });
-      return data.success;
+      return data;
     },
   });
 

--- a/apps/soritor/src/hooks/useTicketStackForm.ts
+++ b/apps/soritor/src/hooks/useTicketStackForm.ts
@@ -27,7 +27,8 @@ export const useTicketStackForm = () => {
   const onSubmit = async (data: FormSchemaType) => {
     const { universityId, reservationId } = data;
 
-    await mutateAsync({ universityId, reservationId });
+    const response = await mutateAsync({ universityId, reservationId });
+    return response.ticket;
   };
 
   return { form, onSubmit, isPending };

--- a/apps/soritor/src/pages/buy-ticket/_components/CompleteActivity.tsx
+++ b/apps/soritor/src/pages/buy-ticket/_components/CompleteActivity.tsx
@@ -9,6 +9,7 @@ import {
   ActivityContent,
   ActivityFooter,
   ActivityHeader,
+  ActivityParams,
 } from "./Activity";
 
 import CompleteBackgroudImg from "/ticketingComplete.png";
@@ -16,18 +17,32 @@ import Ticketing3DImg from "/complete3DTicket.png";
 
 import Image from "@/components/Image";
 
+import { useQueryDepositUrl } from "@/hooks/queries/useQueryDepositUrl";
+
 import { handleCopyClipBoard } from "@/utils/handleCopyToClipboard";
 
-const CompleteActivity: ActivityComponentType = () => {
+interface CompleteParams extends ActivityParams {
+  ticketId: number;
+  eventId: number;
+}
+
+const CompleteActivity: ActivityComponentType<CompleteParams> = ({
+  params,
+}) => {
+  const { ticketId, eventId } = params;
+
   const [searchParams] = useSearchParams();
   const univName = searchParams.get("univName");
   const univId = searchParams.get("univId") as string;
 
   const routeUrl = `/home?select-univ=${univName}&id=${univId}`;
 
-  const depositAccount = "국민 12345-78-9101112 UKET";
-
   const { toast } = useToast();
+  const { data: deposit } = useQueryDepositUrl(
+    ticketId,
+    eventId,
+    "입금 확인중",
+  );
 
   return (
     <AppScreen
@@ -48,27 +63,31 @@ const CompleteActivity: ActivityComponentType = () => {
               alt="티켓 이미지"
               className="animate-rotate-axis w-[180px]"
             />
-            <div className="z-20 mt-10 flex flex-col justify-start gap-5 text-center">
-              <h1 className="text-[23px] font-black">
-                <p>예매 정보가 등록되었습니다.</p>
-                <p>입금 후 예매가 완료됩니다.</p>
-              </h1>
-              <h6 className="text-desc text-base font-medium">
-                공연 티켓가 ₩15,000
-              </h6>
-              <div className="flex items-center gap-2">
-                <p className="text-base font-normal text-[#8989A1]">
-                  {depositAccount}
-                </p>
-
-                <p
-                  className="text-brand decoration-brand cursor-pointer font-bold underline decoration-solid decoration-1 underline-offset-2"
-                  onClick={() => handleCopyClipBoard(depositAccount, toast)}
-                >
-                  복사
-                </p>
+            {deposit && (
+              <div className="z-20 mt-10 flex flex-col justify-start gap-5 text-center">
+                <h1 className="text-[23px] font-black">
+                  <p>예매 정보가 등록되었습니다.</p>
+                  <p>입금 후 예매가 완료됩니다.</p>
+                </h1>
+                <h6 className="text-desc text-base font-medium">
+                  공연 티켓가 ₩{deposit.ticketPrice}
+                </h6>
+                <div className="flex items-center gap-2">
+                  <div className="text-base font-normal text-[#8989A1]">
+                    <span>{deposit.accountNumber} </span>
+                    <span>{deposit.accountOwner}</span>
+                  </div>
+                  <p
+                    className="text-brand decoration-brand cursor-pointer font-bold underline decoration-solid decoration-1 underline-offset-2"
+                    onClick={() =>
+                      handleCopyClipBoard(deposit.accountNumber ?? "", toast)
+                    }
+                  >
+                    복사
+                  </p>
+                </div>
               </div>
-            </div>
+            )}
             <Image
               src={CompleteBackgroudImg}
               alt="티켓팅 완료 이미지"
@@ -80,6 +99,7 @@ const CompleteActivity: ActivityComponentType = () => {
               isLast
               activityName={"MainActivity" as never}
               routeUrl={routeUrl}
+              depositUrl={deposit?.depositUrl}
               disabled={false}
             ></NextButton>
           </ActivityFooter>

--- a/apps/soritor/src/pages/buy-ticket/_components/NextButton.tsx
+++ b/apps/soritor/src/pages/buy-ticket/_components/NextButton.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { LoaderCircleIcon } from "@uket/ui/components/ui/icon";
 import { Button } from "@uket/ui/components/ui/button";
 
@@ -13,13 +14,22 @@ interface NextButtonProps
   disabled: boolean;
   routeUrl?: string;
   isLast?: boolean;
+  depositUrl?: string;
   params?: {
-    form: FormType;
+    form?: FormType;
   } & Record<string, unknown>;
 }
 
 const NextButton = (as: NextButtonProps) => {
-  const { activityName, disabled, params, routeUrl, isLast, ...props } = as;
+  const {
+    activityName,
+    disabled,
+    params,
+    routeUrl,
+    isLast,
+    depositUrl,
+    ...props
+  } = as;
   const { push, pop } = useTicketFlow();
   const { onSubmit, isPending } = useTicketStackForm();
 
@@ -36,17 +46,21 @@ const NextButton = (as: NextButtonProps) => {
       navigate(routeUrl as any, { replace: true });
       return;
     } else if (activityName === "QuestionActivity" && form) {
-      await onSubmit(form.getValues());
+      const data = await onSubmit(form.getValues());
+      push(activityName, {
+        ...params,
+        ticketId: data.ticketId,
+        eventId: data.eventId,
+      });
+      return;
     }
 
     push(activityName, params || {});
   };
 
-  // 카카오로 연결하기는 따로 handleClick을 만들어줘야함.
-
   return (
     <>
-      {isLast ? (
+      {isLast && depositUrl ? (
         <div className="mb-5 flex w-full flex-row justify-center gap-3 px-4 sm:flex-row">
           <Button
             className="border-brand text-brand grow basis-1/2 border bg-white hover:bg-slate-100"
@@ -57,12 +71,12 @@ const NextButton = (as: NextButtonProps) => {
             나중에 하기
           </Button>
           <Button
-            className="bg-brand border-brand hover:bg-brandHover grow basis-1/2 border text-white"
-            onClick={handleClick}
-            disabled={disabled}
-            {...props}
+            asChild
+            className="bg-brand border-brand hover:bg-brandHover grow basis-1/2 border"
           >
-            카카오로 입금하기
+            <Link to={depositUrl} className="text-white">
+              카카오로 입금하기
+            </Link>
           </Button>
         </div>
       ) : (

--- a/apps/soritor/src/pages/buy-ticket/_components/QuestionActivity.tsx
+++ b/apps/soritor/src/pages/buy-ticket/_components/QuestionActivity.tsx
@@ -15,15 +15,16 @@ import {
 
 interface QuestionParams extends ActivityParams {
   univName: string;
-  showId: string;
   showDate: string;
   showTime: string;
+  eventId: number;
+  ticketId: number;
 }
 
 const QuestionActivity: ActivityComponentType<QuestionParams> = ({
   params,
 }) => {
-  const { form, showDate, univName, showTime } = params;
+  const { showDate, univName, showTime, eventId, ticketId } = params;
 
   return (
     <AppScreen appBar={{ border: false, height: "56px" }}>
@@ -45,7 +46,10 @@ const QuestionActivity: ActivityComponentType<QuestionParams> = ({
               type="submit"
               activityName={"CompleteActivity" as never}
               disabled={false}
-              params={{ form }}
+              params={{
+                ticketId: ticketId,
+                eventId: eventId,
+              }}
             ></NextButton>
           </ActivityFooter>
         </ActivityContent>

--- a/apps/soritor/src/pages/ticket-list/_components/QrcodeAndDeposit.tsx
+++ b/apps/soritor/src/pages/ticket-list/_components/QrcodeAndDeposit.tsx
@@ -10,6 +10,8 @@ import { useQueryDepositUrl } from "@/hooks/queries/useQueryDepositUrl";
 
 import { TicketItem } from "@/types/ticketType";
 
+import { handleCopyClipBoard } from "@/utils/handleCopyToClipboard";
+
 interface QrcodeAndDepositProps {
   ticketId: TicketItem["ticketId"];
   eventId: TicketItem["eventId"];
@@ -32,13 +34,6 @@ const QrcodeAndDeposit = (props: QrcodeAndDepositProps) => {
 
   const handleReissueQRCode = () => {
     refetch();
-  };
-
-  const handleCopyDepositUrl = () => {
-    navigator.clipboard.writeText(deposit?.accountNumber ?? "");
-    toast({
-      title: "계좌번호를 복사했어요!",
-    });
   };
 
   return (
@@ -88,7 +83,9 @@ const QrcodeAndDeposit = (props: QrcodeAndDepositProps) => {
               <Button
                 variant="link"
                 className="text-brand cursor-pointer px-1 font-bold"
-                onClick={handleCopyDepositUrl}
+                onClick={() =>
+                  handleCopyClipBoard(deposit?.accountNumber ?? "", toast)
+                }
               >
                 복사
               </Button>

--- a/apps/soritor/src/types/showType.ts
+++ b/apps/soritor/src/types/showType.ts
@@ -33,5 +33,6 @@ export interface TicketResponse {
   ticket: {
     userId: number;
     ticketId: number;
+    eventId: number;
   };
 }


### PR DESCRIPTION
## 연관된 이슈
> ex) #128 

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 티켓 예매 완료 화면 계좌 정보 조회 api 연결 

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점
- 내 티켓 확인에서 계좌 복사 시, 출력되는 toast 메세지를 티켓 예매 완료 화면에서의 toast 메세지와 통일시켰습니다. `/pages/ticket-list/_components/QrcodeAndDeposit.tsx`와 `/utils/handleCopyToClipboard.ts` 참고하시면 됩니다.

- 계좌정보 조회할때 필요한 `evnetId`와 `ticketId`를 더 효율적으로 관리하고 싶은데, 더 좋은 방법이 생각나지 않아서 이 방법으로 구현해놓은 상황입니다. 더 좋은 생각이 나면 말씀해주세요!!
현재 흐름은 아래와 같이 구현되어있습니다.
   1) 날짜 선택
   2) 시간 선택
   3) 다음으로 선택하면 `NextButton.tsx`에서 티켓 예매 api를 연결하고 계좌 정보 조회에 필요한 `ticketId`와 `eventId`를 받아고 질의응답 화면으로 넘어갑니다.
   4) 질의응답 화면에서는 `NextButton.tsx`에서 parameter로 받은 ticketId와 eventId를 티켓 완료 페이지로 넘깁니다.
   5) 티켓 완료 페이지에서는  질의응답화면에서 받은 ticketId와 eventId를 바탕으로 계좌정보를 조회하여 화면에 보여줍니다.
   



## 💬 리뷰 요구사항(선택)


---
🚨 **이슈를 닫아주세요!**
> ex) close #128
