### PR TITLE
refactor: 에러 핸들링 방식 리팩토링

### DIFF
--- a/apps/soritor/src/api/auth.ts
+++ b/apps/soritor/src/api/auth.ts
@@ -39,10 +39,20 @@ export const reissue = async () => {
   const refreshToken = getRefreshToken("refreshToken");
   const accessToken = getAccessToken();
 
-  const { data } = await fetcher.post("/auth/reissue", {
-    accessToken,
-    refreshToken,
-  });
+  const { data } = await fetcher.post(
+    "/auth/reissue",
+    {
+      accessToken,
+      refreshToken,
+    },
+    {
+      mode: "TOAST_UI",
+      errorContent: {
+        title: '토큰 갱신에 오류가 발생했어요.',
+        description: '다시 로그인 해주세요.',
+      }
+    },
+  );
 
   const { accessToken: newAccessToken } = data;
 

--- a/apps/soritor/src/api/auth.ts
+++ b/apps/soritor/src/api/auth.ts
@@ -7,13 +7,13 @@ import { LoginRequestParams } from "@/types/authType";
 import { getAccessToken } from "@/utils/handleToken";
 import { getRefreshToken } from "@/utils/handleCookie";
 
-import { instance } from "./instance";
+import { fetcher } from "./instance";
 
 export const login = async ({ code, provider }: LoginRequestParams) => {
   const redirect_uri =
     provider === "google" ? GOOGLE_REDIRECT_URI : KAKAO_REDIRECT_URI;
 
-  const { data } = await instance.post(`/auth/login/${provider}`, {
+  const { data } = await fetcher.post(`/auth/login/${provider}`, {
     code,
     redirectUri: redirect_uri,
   });
@@ -30,7 +30,7 @@ export const signup = async ({
     phoneNumber: userPhone,
   };
 
-  const { data } = await instance.post("/users/register", baseBody);
+  const { data } = await fetcher.post("/users/register", baseBody);
 
   return data;
 };
@@ -39,7 +39,7 @@ export const reissue = async () => {
   const refreshToken = getRefreshToken("refreshToken");
   const accessToken = getAccessToken();
 
-  const { data } = await instance.post("/auth/reissue", {
+  const { data } = await fetcher.post("/auth/reissue", {
     accessToken,
     refreshToken,
   });

--- a/apps/soritor/src/api/email.ts
+++ b/apps/soritor/src/api/email.ts
@@ -4,13 +4,13 @@ import {
   EmailAuthVerifyParams,
 } from "@/types/emailType";
 
-import { instance } from "./instance";
+import { fetcher } from "./instance";
 
 export const requestEmailAuth = async ({
   email,
   universityId,
 }: EmailAuthRequestParams) => {
-  const { data } = await instance.post<EmailAuthResponse>(`/email/send`, {
+  const { data } = await fetcher.post<EmailAuthResponse>(`/email/send`, {
     email,
     universityId,
   });
@@ -23,7 +23,7 @@ export const verifyEmailAuth = async ({
   universityId,
   authCode,
 }: EmailAuthVerifyParams) => {
-  const { data } = await instance.post<EmailAuthResponse>(`/email/verify`, {
+  const { data } = await fetcher.post<EmailAuthResponse>(`/email/verify`, {
     email,
     universityId,
     authCode,

--- a/apps/soritor/src/api/instance.ts
+++ b/apps/soritor/src/api/instance.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 
 import {
   clearAccessToken,
@@ -6,8 +6,35 @@ import {
   setAccessToken,
 } from "@/utils/handleToken";
 import { clearRefreshToken } from "@/utils/handleCookie";
+import CustomAxiosError from "@/utils/customError";
 
 import { reissue } from "./auth";
+
+type ErrorDisplayMode = "TOAST_UI" | "BOUNDARY";
+
+// 기본적인 커스텀 config는 mode를 포함합니다.
+interface RequestConfigBase extends AxiosRequestConfig {
+  mode: ErrorDisplayMode;
+}
+
+// 토스트를 표시하는 커스텀 config 입니다.
+// errorContent라는 추가적인 필드를 갖습니다. 이는 토스트에 표시할 제목, 내용을 구성합니다.
+interface RequestConfigWithToast extends RequestConfigBase {
+  mode: "TOAST_UI";
+  errorContent?: {
+    title: string;
+    description: string;
+  } | null;
+}
+
+// 에러를 Error Boundary로 처리할때 사용하는 커스텀 config 입니다.
+// errorContent는 사용하지 않기 때문에 제외합니다.
+interface RequestConfigWithBoundary extends RequestConfigBase {
+  mode: "BOUNDARY";
+}
+
+// 사용자가 설정한 mode에 따라 config의 타입이 바뀝니다.
+export type RequestConfig = RequestConfigWithToast | RequestConfigWithBoundary;
 
 const BASE_URL = `${import.meta.env.VITE_BASE_URL}`;
 const SERVER_VERSION = "/api/v1";
@@ -61,8 +88,9 @@ instance.interceptors.response.use(
   async response => {
     return response;
   },
-  async error => {
-    const { status, config } = error.response;
+  async (error: AxiosError) => {
+    const { status } = error;
+    const config = error.config as RequestConfig;
 
     if (
       (status === 404 || status === 403 || status === 400) &&
@@ -75,17 +103,51 @@ instance.interceptors.response.use(
 
     if (
       status === 401 &&
-      (AUTH_REQUIRED_PATH.includes(config.url) ||
-        isDynamicUrlMatched(config.url))
+      (AUTH_REQUIRED_PATH.includes(config.url!) ||
+        isDynamicUrlMatched(config.url!))
     ) {
       const newAccessToken = await reissue();
 
       setAccessToken(newAccessToken);
 
-      config.headers.Authorization = `Bearer ${newAccessToken}`;
+      config.headers!.Authorization = `Bearer ${newAccessToken}`;
 
       return instance(config);
     }
-    return Promise.reject(error);
+    return Promise.reject(
+      new CustomAxiosError(
+        error,
+        config.mode === "TOAST_UI" && config.errorContent
+          ? config.errorContent
+          : null,
+        config.mode === "TOAST_UI",
+      ),
+    );
   },
 );
+
+const request = async <T>(promise: Promise<AxiosResponse<T>>) => {
+  const response = await promise;
+  return response;
+};
+
+const defaultConfig: RequestConfig = { mode: "BOUNDARY" };
+
+export const fetcher = {
+  get: <T = any>(pathname: string, config?: RequestConfig) =>
+    request<T>(instance.get(pathname, { ...defaultConfig, ...config })),
+  post: <T = any>(pathname: string, data?: unknown, config?: RequestConfig) =>
+    request<T>(
+      instance.post<T>(pathname, data, { ...defaultConfig, ...config }),
+    ),
+  put: <T = any>(pathname: string, data?: unknown, config?: RequestConfig) =>
+    request<T>(
+      instance.put<T>(pathname, data, { ...defaultConfig, ...config }),
+    ),
+  delete: <T = any>(pathname: string, config?: RequestConfig) =>
+    request<T>(instance.delete<T>(pathname, { ...defaultConfig, ...config })),
+  patch: <T = any>(pathname: string, data?: unknown, config?: RequestConfig) =>
+    request<T>(
+      instance.patch<T>(pathname, data, { ...defaultConfig, ...config }),
+    ),
+};

--- a/apps/soritor/src/api/instance.ts
+++ b/apps/soritor/src/api/instance.ts
@@ -89,7 +89,7 @@ instance.interceptors.response.use(
     return response;
   },
   async (error: AxiosError) => {
-    const { status } = error;
+    const { status } = error.response!;
     const config = error.config as RequestConfig;
 
     if (

--- a/apps/soritor/src/api/instance.ts
+++ b/apps/soritor/src/api/instance.ts
@@ -23,7 +23,7 @@ interface RequestConfigWithToast extends RequestConfigBase {
   mode: "TOAST_UI";
   errorContent?: {
     title: string;
-    description: string;
+    description?: string;
   } | null;
 }
 

--- a/apps/soritor/src/api/show.ts
+++ b/apps/soritor/src/api/show.ts
@@ -8,12 +8,13 @@ import {
 
 import { getAccessToken } from "@/utils/handleToken";
 
-import { instance } from "./instance";
+import { fetcher } from "./instance";
 
 export const getShowList = async (id: string | null) => {
   const accessToken = getAccessToken();
 
-  const { data } = await instance.get<ShowInfoResponse>(`/events/${id}/shows`, {
+  const { data } = await fetcher.get<ShowInfoResponse>(`/events/${id}/shows`, {
+    mode: "BOUNDARY",
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
@@ -28,9 +29,10 @@ export const getReservationList = async (
 ) => {
   const accessToken = getAccessToken();
 
-  const { data } = await instance.get<ReservationInfoResponse>(
+  const { data } = await fetcher.get<ReservationInfoResponse>(
     `/events/shows/${id}/reservations/${reservationUserType}`,
     {
+      mode: "BOUNDARY",
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
@@ -43,6 +45,6 @@ export const getReservationList = async (
 export const buyTicket = async (
   formData: FormSchemaType,
 ): Promise<TicketResponse> => {
-  const { data } = await instance.post<TicketResponse>("/tickets", formData);
+  const { data } = await fetcher.post<TicketResponse>("/tickets", formData);
   return data;
 };

--- a/apps/soritor/src/api/survey.ts
+++ b/apps/soritor/src/api/survey.ts
@@ -1,14 +1,14 @@
 import { SurveyRequest, SurveyResponse } from "@/types/surveyType";
 
-import { instance } from "./instance";
+import { fetcher } from "./instance";
 
 export const getSurveyList = async (id: string | null) => {
-  const { data } = await instance.get<SurveyResponse>(`/events/${id}/survey`);
+  const { data } = await fetcher.get<SurveyResponse>(`/events/${id}/survey`);
 
   return { surveyId: data.surveyId, surveys: data.forms };
 };
 
 export const submitSurvey = async (surveyForm: SurveyRequest) => {
-  const { data } = await instance.post("/survey", surveyForm);
+  const { data } = await fetcher.post("/survey", surveyForm);
   return data;
 };

--- a/apps/soritor/src/api/term.ts
+++ b/apps/soritor/src/api/term.ts
@@ -1,15 +1,15 @@
 import { TermAgreedParams, TermAgreedResponse, TermListResponse } from "@/types/termType";
 
-import { instance } from "./instance";
+import { fetcher } from "./instance";
 
 export const getTermList = async () => {
-  const { data } = await instance.get<TermListResponse>("/terms");
+  const { data } = await fetcher.get<TermListResponse>("/terms");
 
   return data.items;
 };
 
 export const agreeTerm = async (agreements: TermAgreedParams[]) => {
-  const { data } = await instance.post<TermAgreedResponse>("/terms/agreement", agreements);
+  const { data } = await fetcher.post<TermAgreedResponse>("/terms/agreement", agreements);
 
   return data;
 };

--- a/apps/soritor/src/api/ticket.ts
+++ b/apps/soritor/src/api/ticket.ts
@@ -27,7 +27,13 @@ export const getMyTicketList = async () => {
 };
 
 export const cancelTicket = async (ticketId: TicketItem["ticketId"]) => {
-  const { data } = await fetcher.delete(`/tickets/${ticketId}/cancel`);
+  const { data } = await fetcher.delete(`/tickets/${ticketId}/cancel`, {
+    mode: "TOAST_UI",
+    errorContent: {
+      title: '티켓 취소 오류',
+      description: '잠시 후 다시 시도해 주세요.'
+    }
+  });
 
   return data;
 };

--- a/apps/soritor/src/api/ticket.ts
+++ b/apps/soritor/src/api/ticket.ts
@@ -5,12 +5,13 @@ import {
   TicketItem,
 } from "@/types/ticketType";
 
-import { instance } from "./instance";
+import { fetcher } from "./instance";
 
 export const getTicketQRCode = async (ticketId: TicketItem["ticketId"]) => {
-  const { data } = await instance.get<MyTicketQRCodeResponse>(
+  const { data } = await fetcher.get<MyTicketQRCodeResponse>(
     `/tickets/${ticketId}/qrcode`,
     {
+      mode: "BOUNDARY",
       responseType: "blob",
     },
   );
@@ -20,19 +21,19 @@ export const getTicketQRCode = async (ticketId: TicketItem["ticketId"]) => {
 
 export const getMyTicketList = async () => {
   const { data } =
-    await instance.get<MyTicketListInfoResponse>("/users/tickets");
+    await fetcher.get<MyTicketListInfoResponse>("/users/tickets");
 
   return data;
 };
 
 export const cancelTicket = async (ticketId: TicketItem["ticketId"]) => {
-  const { data } = await instance.delete(`/tickets/${ticketId}/cancel`);
+  const { data } = await fetcher.delete(`/tickets/${ticketId}/cancel`);
 
   return data;
 };
 
 export const getDepositUrl = async (ticketId: TicketItem["ticketId"]) => {
-  const { data } = await instance.get<DepositResponse>(
+  const { data } = await fetcher.get<DepositResponse>(
     `/events/${ticketId}/account`,
   );
 

--- a/apps/soritor/src/api/univ.ts
+++ b/apps/soritor/src/api/univ.ts
@@ -1,4 +1,4 @@
-import { instance } from "@/api/instance";
+import { fetcher } from "@/api/instance";
 
 import {
   FestivalUniversityResponse,
@@ -9,20 +9,21 @@ import {
 
 export const getFestivalUniversityList = async () => {
   const { data } =
-    await instance.get<FestivalUniversityResponse>(`/universities`);
+    await fetcher.get<FestivalUniversityResponse>(`/universities`);
 
   return data.items;
 };
 
 export const getFestiavalByUniversity = async (id: string | null) => {
-  const { data } = await instance.get<FestivalInfoResponse>(
+  const { data } = await fetcher.get<FestivalInfoResponse>(
     `/universities/${id}/event`,
   );
+
   return data;
 };
 
 export const searchUniversityList = async () => {
-  const { data } = await instance.get<UniversityResponse>(
+  const { data } = await fetcher.get<UniversityResponse>(
     `/universities/certification`,
   );
 

--- a/apps/soritor/src/api/user.ts
+++ b/apps/soritor/src/api/user.ts
@@ -26,7 +26,7 @@ export const updateUserInfo = async ({
 
 export const deleteUserInfo = async () => {
   const { data } = await fetcher.post<DeleteUserResponse>(
-    "/users/delete2",
+    "/users/delete",
     null,
     {
       mode: "TOAST_UI",

--- a/apps/soritor/src/api/user.ts
+++ b/apps/soritor/src/api/user.ts
@@ -25,7 +25,17 @@ export const updateUserInfo = async ({
 };
 
 export const deleteUserInfo = async () => {
-  const { data } = await fetcher.post<DeleteUserResponse>("/users/delete");
+  const { data } = await fetcher.post<DeleteUserResponse>(
+    "/users/delete2",
+    null,
+    {
+      mode: "TOAST_UI",
+      errorContent: {
+        title: "회원탈퇴 오류",
+        description: "잠시 후 다시 시도해 주세요.",
+      },
+    },
+  );
 
   return data;
 };

--- a/apps/soritor/src/api/user.ts
+++ b/apps/soritor/src/api/user.ts
@@ -4,10 +4,10 @@ import {
   DeleteUserResponse,
 } from "@/types/userType";
 
-import { instance } from "./instance";
+import { fetcher } from "./instance";
 
 export const getUserInfo = async () => {
-  const { data } = await instance.get("/users/info");
+  const { data } = await fetcher.get("/users/info");
 
   return data;
 };
@@ -16,7 +16,7 @@ export const updateUserInfo = async ({
   depositorName,
   phoneNumber,
 }: UserInfoUpdateRequest) => {
-  const { data } = await instance.patch<UserInfoResponse>("/users/info", {
+  const { data } = await fetcher.patch<UserInfoResponse>("/users/info", {
     depositorName,
     phoneNumber,
   });
@@ -25,7 +25,7 @@ export const updateUserInfo = async ({
 };
 
 export const deleteUserInfo = async () => {
-  const { data } = await instance.post<DeleteUserResponse>("/users/delete");
+  const { data } = await fetcher.post<DeleteUserResponse>("/users/delete");
 
   return data;
 };

--- a/apps/soritor/src/components/provider/QueryProvider.tsx
+++ b/apps/soritor/src/components/provider/QueryProvider.tsx
@@ -7,7 +7,7 @@ import {
   QueryClientProvider,
 } from "@tanstack/react-query";
 
-import { successToast } from "@/constants/successToast";
+import { SUCCESS_TOAST } from "@/constants/success_toast";
 
 import { errorHandler } from "@/utils/errorHandler";
 import CustomAxiosError from "@/utils/customError";
@@ -36,9 +36,9 @@ const queryClient = new QueryClient({
       onError: error => errorHandler(error as CustomAxiosError),
       onSuccess: (data, _, context) => {
         const mutationKey = (context as any)
-          ?.mutationKey as keyof typeof successToast;
-        if (mutationKey in successToast) {
-          successToast[mutationKey].onSuccess();
+          ?.mutationKey as keyof typeof SUCCESS_TOAST;
+        if (mutationKey in SUCCESS_TOAST) {
+          SUCCESS_TOAST[mutationKey].onSuccess();
         }
       },
     },

--- a/apps/soritor/src/components/provider/QueryProvider.tsx
+++ b/apps/soritor/src/components/provider/QueryProvider.tsx
@@ -24,7 +24,13 @@ const queryClient = new QueryClient({
       staleTime: 1000 * 60 * 10,
     },
     mutations: {
-      throwOnError: true,
+      throwOnError: error => {
+        // error는 axios interceptor에서 전달받은 에러 객체입니다.(CustomAxiosError)
+        // error.isToast는 mode === 'TOAST_UI'를 의미합니다.
+        // 따라서, 'TOAST_UI'라면 에러를 전파하지 않습니다 (return false)
+        return !error.isToast;
+      },
+      onError: error => errorHandler(error as CustomAxiosError),
     },
   },
   queryCache: new QueryCache({

--- a/apps/soritor/src/components/provider/QueryProvider.tsx
+++ b/apps/soritor/src/components/provider/QueryProvider.tsx
@@ -6,6 +6,8 @@ import {
   QueryClientProvider,
 } from "@tanstack/react-query";
 
+import { successToast } from "@/constants/successToast";
+
 import { useHandleError } from "@/utils/errorHandler";
 import CustomAxiosError from "@/utils/customError";
 
@@ -32,7 +34,18 @@ const queryClient = new QueryClient({
         // 따라서, 'TOAST_UI'라면 에러를 전파하지 않습니다 (return false)
         return !error.isToast;
       },
-      onError: error => errorHandler(error as CustomAxiosError),
+      onError: error => {
+        errorHandler(error as CustomAxiosError);
+      },
+      onSuccess: (data, _, context) => {
+        if ((context as any).mutationKey in successToast) {
+          const mutationKey = (context as any)
+            ?.mutationKey as keyof typeof successToast;
+          if (mutationKey in successToast) {
+            successToast[mutationKey].onSuccess();
+          }
+        }
+      },
     },
   },
   queryCache: new QueryCache({

--- a/apps/soritor/src/components/provider/QueryProvider.tsx
+++ b/apps/soritor/src/components/provider/QueryProvider.tsx
@@ -15,6 +15,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       throwOnError: error => {
+        if (error.response?.status === 500) return true;
         // error는 axios interceptor에서 전달받은 에러 객체입니다.(CustomAxiosError)
         // error.isToast는 mode === 'TOAST_UI'를 의미합니다.
         // 따라서, 'TOAST_UI'라면 에러를 전파하지 않습니다 (return false)
@@ -25,6 +26,7 @@ const queryClient = new QueryClient({
     },
     mutations: {
       throwOnError: error => {
+        if (error.response?.status === 500) return true;
         // error는 axios interceptor에서 전달받은 에러 객체입니다.(CustomAxiosError)
         // error.isToast는 mode === 'TOAST_UI'를 의미합니다.
         // 따라서, 'TOAST_UI'라면 에러를 전파하지 않습니다 (return false)

--- a/apps/soritor/src/components/provider/QueryProvider.tsx
+++ b/apps/soritor/src/components/provider/QueryProvider.tsx
@@ -1,10 +1,25 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryCache,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+
+import { useHandleError } from "@/utils/errorHandler";
+import CustomAxiosError from "@/utils/customError";
+
+const { errorHandler } = useHandleError();
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      throwOnError: true,
+      throwOnError: error => {
+        // error는 axios interceptor에서 전달받은 에러 객체입니다.(CustomAxiosError)
+        // error.isToast는 mode === 'TOAST_UI'를 의미합니다.
+        // 따라서, 'TOAST_UI'라면 에러를 전파하지 않습니다 (return false)
+        return !error.isToast;
+      },
       retry: false,
       staleTime: 1000 * 60 * 10,
     },
@@ -12,6 +27,10 @@ const queryClient = new QueryClient({
       throwOnError: true,
     },
   },
+  queryCache: new QueryCache({
+    // throwOnError가 false일 경우에만, onError 핸들러가 호출됩니다.
+    onError: error => errorHandler(error as CustomAxiosError),
+  }),
 });
 
 const QueryProvider = ({ children }: { children: React.ReactNode }) => {

--- a/apps/soritor/src/components/provider/QueryProvider.tsx
+++ b/apps/soritor/src/components/provider/QueryProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable react-hooks/rules-of-hooks */
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import {
@@ -8,10 +9,8 @@ import {
 
 import { successToast } from "@/constants/successToast";
 
-import { useHandleError } from "@/utils/errorHandler";
+import { errorHandler } from "@/utils/errorHandler";
 import CustomAxiosError from "@/utils/customError";
-
-const { errorHandler } = useHandleError();
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -34,16 +33,12 @@ const queryClient = new QueryClient({
         // 따라서, 'TOAST_UI'라면 에러를 전파하지 않습니다 (return false)
         return !error.isToast;
       },
-      onError: error => {
-        errorHandler(error as CustomAxiosError);
-      },
+      onError: error => errorHandler(error as CustomAxiosError),
       onSuccess: (data, _, context) => {
-        if ((context as any).mutationKey in successToast) {
-          const mutationKey = (context as any)
-            ?.mutationKey as keyof typeof successToast;
-          if (mutationKey in successToast) {
-            successToast[mutationKey].onSuccess();
-          }
+        const mutationKey = (context as any)
+          ?.mutationKey as keyof typeof successToast;
+        if (mutationKey in successToast) {
+          successToast[mutationKey].onSuccess();
         }
       },
     },

--- a/apps/soritor/src/constants/successToast.ts
+++ b/apps/soritor/src/constants/successToast.ts
@@ -1,0 +1,17 @@
+import { toast } from "@uket/ui/components/ui/sonner";
+
+import { navigateTo } from "../utils/globalNavigate";
+
+export const successToast = {
+  deleteUser: {
+    onSuccess: () => {
+      navigateTo("/", { replace: true });
+      toast.success("정상적으로 탈퇴되었습니다.");
+    },
+  },
+  cancelTicket: {
+    onSuccess: () => {
+      toast.success("예매가 취소되었습니다.");
+    },
+  },
+};

--- a/apps/soritor/src/constants/success_toast.ts
+++ b/apps/soritor/src/constants/success_toast.ts
@@ -2,7 +2,7 @@ import { toast } from "@uket/ui/components/ui/sonner";
 
 import { navigateTo } from "../utils/globalNavigate";
 
-export const successToast = {
+export const SUCCESS_TOAST = {
   deleteUser: {
     onSuccess: () => {
       navigateTo("/", { replace: true });

--- a/apps/soritor/src/hooks/mutations/useMutationCancelTicket.ts
+++ b/apps/soritor/src/hooks/mutations/useMutationCancelTicket.ts
@@ -5,12 +5,14 @@ import { cancelTicket } from "@/api/ticket";
 
 import { CancelTicketResponse } from "@/types/ticketType";
 
-
-
 export const useMutationCancelTicket = () => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
+    mutationKey: ["cancelTicket"],
+    onMutate: () => {
+      return { mutationKey: "cancelTicket" };
+    },
     mutationFn: (ticketId: number) => cancelTicket(ticketId),
     onSuccess: (data: CancelTicketResponse) => {
       queryClient.invalidateQueries({ queryKey: ["my-ticket-list"] });

--- a/apps/soritor/src/hooks/mutations/useMutationDeleteUser.ts
+++ b/apps/soritor/src/hooks/mutations/useMutationDeleteUser.ts
@@ -1,28 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
-import { useQueryClient } from "@tanstack/react-query";
 
 import { deleteUserInfo } from "@/api/user";
 
-import { DeleteUserResponse } from "@/types/userType";
-
-import { clearAccessToken } from "@/utils/handleToken";
-import { clearRefreshToken } from "@/utils/handleCookie";
-
-
 export const useMutationDeleteUser = () => {
-  const queryClient = useQueryClient();
-
   const mutation = useMutation({
-    mutationKey: ["deleteUser"],
     mutationFn: deleteUserInfo,
     onMutate: () => {
       return { mutationKey: "deleteUser" };
-    },
-    onSuccess: (data: DeleteUserResponse) => {
-      queryClient.removeQueries({ queryKey: ["user-info"] });
-      clearRefreshToken("refreshToken");
-      clearAccessToken("accessToken");
-      return data;
     },
   });
 

--- a/apps/soritor/src/hooks/mutations/useMutationDeleteUser.ts
+++ b/apps/soritor/src/hooks/mutations/useMutationDeleteUser.ts
@@ -8,17 +8,20 @@ import { DeleteUserResponse } from "@/types/userType";
 import { clearAccessToken } from "@/utils/handleToken";
 import { clearRefreshToken } from "@/utils/handleCookie";
 
+
 export const useMutationDeleteUser = () => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: () => deleteUserInfo(),
+    mutationKey: ["deleteUser"],
+    mutationFn: deleteUserInfo,
+    onMutate: () => {
+      return { mutationKey: "deleteUser" };
+    },
     onSuccess: (data: DeleteUserResponse) => {
       queryClient.removeQueries({ queryKey: ["user-info"] });
-
       clearRefreshToken("refreshToken");
       clearAccessToken("accessToken");
-
       return data;
     },
   });

--- a/apps/soritor/src/hooks/queries/useQueryDepositUrl.ts
+++ b/apps/soritor/src/hooks/queries/useQueryDepositUrl.ts
@@ -4,19 +4,16 @@ import { getDepositUrl } from "@/api/ticket";
 
 import { TicketItem } from "@/types/ticketType";
 
-
 export const useQueryDepositUrl = (
-  ticketId: TicketItem['ticketId'],
+  ticketId: TicketItem["ticketId"],
   eventId: TicketItem["eventId"],
   ticketStatus: TicketItem["ticketStatus"],
 ) => {
-  const { data, error } = useQuery({
+  const { data } = useQuery({
     queryKey: ["deposit", eventId, ticketId],
     queryFn: () => getDepositUrl(eventId),
     enabled: !!eventId && ticketStatus === "입금 확인중",
   });
-
-  if (error) throw error;
 
   return { data };
 };

--- a/apps/soritor/src/hooks/queries/useQueryFestivalByUniversity.ts
+++ b/apps/soritor/src/hooks/queries/useQueryFestivalByUniversity.ts
@@ -4,14 +4,10 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { getFestiavalByUniversity } from "@/api/univ";
 
 export const useQueryFestivalInfoByUniversity = (id: string | null) => {
-  const { data, error } = useSuspenseQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ["festival-info", id],
     queryFn: () => getFestiavalByUniversity(id),
   });
-
-  if (error) {
-    throw error;
-  }
 
   return { data };
 };

--- a/apps/soritor/src/hooks/queries/useQueryFestivalUnivList.ts
+++ b/apps/soritor/src/hooks/queries/useQueryFestivalUnivList.ts
@@ -4,7 +4,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { getFestivalUniversityList } from "@/api/univ";
 
 export const useQueryFestivalUnivList = () => {
-  const { data, error } = useSuspenseQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ["univ-select"],
     queryFn: getFestivalUniversityList,
     select: data => {
@@ -14,10 +14,6 @@ export const useQueryFestivalUnivList = () => {
       }));
     },
   });
-
-  if (error) {
-    throw error;
-  }
 
   return { data };
 };

--- a/apps/soritor/src/hooks/queries/useQueryMyTicketList.ts
+++ b/apps/soritor/src/hooks/queries/useQueryMyTicketList.ts
@@ -5,7 +5,7 @@ import { getMyTicketList } from "@/api/ticket";
 import { formatDate } from "@/utils/handleTicket";
 
 export const useQueryMyTicketList = () => {
-  const { data, error } = useSuspenseQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ["my-ticket-list"],
     queryFn: () => getMyTicketList(),
     select: data => {
@@ -19,10 +19,6 @@ export const useQueryMyTicketList = () => {
     },
     staleTime: 0,
   });
-
-  if (error) {
-    throw error;
-  }
 
   return { data };
 };

--- a/apps/soritor/src/hooks/queries/useQueryReservationList.ts
+++ b/apps/soritor/src/hooks/queries/useQueryReservationList.ts
@@ -8,15 +8,11 @@ export const useQueryReservationList = (
 ) => {
   const userType =
     reservationUserType !== undefined ? reservationUserType : "일반인";
-  const { data, error } = useSuspenseQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ["reservation-info", id, userType],
     queryFn: () => getReservationList(id, userType),
     staleTime: 0,
   });
-
-  if (error) {
-    throw error;
-  }
 
   return { data };
 };

--- a/apps/soritor/src/hooks/queries/useQueryShowList.ts
+++ b/apps/soritor/src/hooks/queries/useQueryShowList.ts
@@ -3,13 +3,10 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { getShowList } from "@/api/show";
 
 export const useQueryShowList = (id: string | null) => {
-  const { data, error } = useSuspenseQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ["show-info", id],
     queryFn: () => getShowList(id),
   });
 
-  if (error) {
-    throw error;
-  }
   return { data };
 };

--- a/apps/soritor/src/hooks/queries/useQuerySurveyList.ts
+++ b/apps/soritor/src/hooks/queries/useQuerySurveyList.ts
@@ -3,13 +3,10 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { getSurveyList } from "@/api/survey";
 
 export const useQuerySurveyList = (eventId: string | null) => {
-  const { data, error } = useSuspenseQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ["survey-list", eventId],
     queryFn: () => getSurveyList(eventId),
   });
 
-  if (error) {
-    throw error;
-  }
   return { data };
 };

--- a/apps/soritor/src/hooks/queries/useQueryTermList.ts
+++ b/apps/soritor/src/hooks/queries/useQueryTermList.ts
@@ -3,14 +3,10 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { getTermList } from "@/api/term";
 
 export const useQueryTermList = () => {
-  const { data, error } = useSuspenseQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ["term-list"],
     queryFn: getTermList,
   });
-
-  if (error) {
-    throw error;
-  }
 
   return { data };
 };

--- a/apps/soritor/src/hooks/queries/useQueryTicketQRCode.ts
+++ b/apps/soritor/src/hooks/queries/useQueryTicketQRCode.ts
@@ -10,7 +10,7 @@ export const useQueryTicketQRCode = (
   ticketId: TicketItem["ticketId"],
   ticketStatus: TicketItem["ticketStatus"],
 ) => {
-  const { data, error, refetch } = useQuery({
+  const { data, refetch } = useQuery({
     queryKey: ["qrcode", ticketId],
     queryFn: () => getTicketQRCode(ticketId),
     select: data => {
@@ -19,10 +19,6 @@ export const useQueryTicketQRCode = (
     staleTime: 0,
     enabled: !!ticketId && ticketStatus !== "입금 확인중",
   });
-
-  if (error) {
-    throw error;
-  }
 
   return { data, refetch };
 };

--- a/apps/soritor/src/hooks/queries/useQueryUniversityList.ts
+++ b/apps/soritor/src/hooks/queries/useQueryUniversityList.ts
@@ -3,14 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { searchUniversityList } from "@/api/univ";
 
 export const useQueryUniversityList = () => {
-  const { data, error } = useQuery({
+  const { data } = useQuery({
     queryKey: ["university-list"],
     queryFn: searchUniversityList,
   });
-
-  if (error) {
-    throw error;
-  }
-
+  
   return { data: data || [] };
 };

--- a/apps/soritor/src/hooks/queries/useQueryUserInfo.ts
+++ b/apps/soritor/src/hooks/queries/useQueryUserInfo.ts
@@ -15,16 +15,12 @@ export const useQueryUserInfo = () => {
 
   if (!accessToken || !refreshToken) return { data: null };
 
-  const { data, error } = useSuspenseQuery<UserInfoResponse>({
+  const { data } = useSuspenseQuery<UserInfoResponse>({
     queryKey: ["user-info"],
     queryFn: () => getUserInfo(),
     refetchOnMount: true,
     refetchOnWindowFocus: true,
   });
-
-  if (error) {
-    throw error;
-  }
 
   return { data: data };
 };

--- a/apps/soritor/src/main.tsx
+++ b/apps/soritor/src/main.tsx
@@ -2,6 +2,7 @@ import { HelmetProvider } from "react-helmet-async";
 import ReactDOM from "react-dom/client";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { inject } from "@vercel/analytics";
+import { Toaster as Sonner } from "@uket/ui/components/ui/sonner";
 import { Routes } from "@generouted/react-router";
 
 import "@uket/ui/globals.css";
@@ -15,6 +16,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <HelmetProvider>
     <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
       <QueryProvider>
+        <Sonner richColors />
         <CookieProvider>
           <Routes />
           <SVGProvider />

--- a/apps/soritor/src/pages/_app.tsx
+++ b/apps/soritor/src/pages/_app.tsx
@@ -1,14 +1,20 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { useEffect } from "react";
 import { Toaster } from "@uket/ui/components/ui/toaster";
-import { Toaster as Sonner } from "@uket/ui/components/ui/sonner";
 
 import Nav from "@/components/Nav";
 import CriticalErrorBoundary from "@/components/error/CriticalErrorBoundary";
 
 import Redirects from "@/utils/redirects";
+import { setGlobalNavigate } from "@/utils/globalNavigate";
 
 const App = () => {
   const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setGlobalNavigate(navigate);
+  }, [navigate]);
 
   return (
     <CriticalErrorBoundary>
@@ -26,7 +32,6 @@ const App = () => {
           </main>
         </div>
         <Toaster className="bottom-0 left-1/2 -translate-x-1/2" />
-        <Sonner richColors />
       </section>
     </CriticalErrorBoundary>
   );

--- a/apps/soritor/src/pages/_app.tsx
+++ b/apps/soritor/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { Outlet, useLocation } from "react-router-dom";
 import { Toaster } from "@uket/ui/components/ui/toaster";
+import { Toaster as Sonner } from "@uket/ui/components/ui/sonner";
 
 import Nav from "@/components/Nav";
 import CriticalErrorBoundary from "@/components/error/CriticalErrorBoundary";
@@ -25,6 +26,7 @@ const App = () => {
           </main>
         </div>
         <Toaster className="bottom-0 left-1/2 -translate-x-1/2" />
+        <Sonner richColors />
       </section>
     </CriticalErrorBoundary>
   );

--- a/apps/soritor/src/pages/buy-ticket/_components/CompleteActivity.tsx
+++ b/apps/soritor/src/pages/buy-ticket/_components/CompleteActivity.tsx
@@ -1,5 +1,4 @@
 import { useSearchParams } from "react-router-dom";
-import { useToast } from "@uket/ui/components/ui/use-toast";
 import { ActivityComponentType } from "@stackflow/react";
 import { AppScreen } from "@stackflow/plugin-basic-ui";
 
@@ -37,7 +36,6 @@ const CompleteActivity: ActivityComponentType<CompleteParams> = ({
 
   const routeUrl = `/home?select-univ=${univName}&id=${univId}`;
 
-  const { toast } = useToast();
   const { data: deposit } = useQueryDepositUrl(
     ticketId,
     eventId,
@@ -80,7 +78,7 @@ const CompleteActivity: ActivityComponentType<CompleteParams> = ({
                   <p
                     className="text-brand decoration-brand cursor-pointer font-bold underline decoration-solid decoration-1 underline-offset-2"
                     onClick={() =>
-                      handleCopyClipBoard(deposit.accountNumber ?? "", toast)
+                      handleCopyClipBoard(deposit.accountNumber ?? "")
                     }
                   >
                     복사

--- a/apps/soritor/src/pages/myinfo/_components/DeleteUserInfoModal.tsx
+++ b/apps/soritor/src/pages/myinfo/_components/DeleteUserInfoModal.tsx
@@ -7,17 +7,27 @@ import {
   DialogTrigger,
 } from "@uket/ui/components/ui/dialog";
 import { Button } from "@uket/ui/components/ui/button";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useMutationDeleteUser } from "@/hooks/mutations/useMutationDeleteUser";
 
+import { clearAccessToken } from "@/utils/handleToken";
+import { clearRefreshToken } from "@/utils/handleCookie";
+
 const DeleteUserInfoModal = () => {
   const [open, setOpen] = useState(false);
-
+  const queryClient = useQueryClient();
   const { mutate } = useMutationDeleteUser();
 
   const handleDeleteUserInfo = () => {
     setOpen(false);
-    mutate();
+    mutate(undefined, {
+      onSuccess: () => {
+        queryClient.removeQueries({ queryKey: ["user-info"] });
+        clearRefreshToken("refreshToken");
+        clearAccessToken("accessToken");
+      },
+    });
   };
 
   return (

--- a/apps/soritor/src/pages/myinfo/_components/DeleteUserInfoModal.tsx
+++ b/apps/soritor/src/pages/myinfo/_components/DeleteUserInfoModal.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useToast } from "@uket/ui/components/ui/use-toast";
 import {
   Dialog,
   DialogClose,
@@ -9,35 +8,16 @@ import {
 } from "@uket/ui/components/ui/dialog";
 import { Button } from "@uket/ui/components/ui/button";
 
-import { useNavigate } from "@/router";
-
 import { useMutationDeleteUser } from "@/hooks/mutations/useMutationDeleteUser";
 
 const DeleteUserInfoModal = () => {
-  const { toast } = useToast();
-
   const [open, setOpen] = useState(false);
 
-  const navigate = useNavigate();
-
-  const mutation = useMutationDeleteUser();
+  const { mutate } = useMutationDeleteUser();
 
   const handleDeleteUserInfo = () => {
     setOpen(false);
-    mutation.mutate(undefined, {
-      onSuccess: () => {
-        toast({
-          title: "회원탈퇴 성공!",
-        });
-        navigate("/", { replace: true });
-      },
-      onError: () => {
-        toast({
-          title: "회원탈퇴 실패",
-          variant: "brandDestructive",
-        });
-      },
-    });
+    mutate();
   };
 
   return (

--- a/apps/soritor/src/pages/myinfo/_components/LogoutModal.tsx
+++ b/apps/soritor/src/pages/myinfo/_components/LogoutModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useToast } from "@uket/ui/components/ui/use-toast";
+import { toast } from "@uket/ui/components/ui/sonner";
 import {
   Dialog,
   DialogClose,
@@ -14,9 +14,8 @@ import { useNavigate } from "@/router";
 import { clearAccessToken } from "@/utils/handleToken";
 import { clearRefreshToken } from "@/utils/handleCookie";
 
-const LogoutModal = () => {
-  const { toast } = useToast();
 
+const LogoutModal = () => {
   const [open, setOpen] = useState(false);
 
   const navigate = useNavigate();
@@ -25,9 +24,7 @@ const LogoutModal = () => {
     clearRefreshToken("refreshToken");
     clearAccessToken("accessToken");
     setOpen(false);
-    toast({
-      title: "로그아웃 성공!",
-    });
+    toast.success("로그아웃이 완료되었습니다.");
     navigate("/", { replace: true });
   };
 

--- a/apps/soritor/src/pages/ticket-list/_components/ConfirmModal.tsx
+++ b/apps/soritor/src/pages/ticket-list/_components/ConfirmModal.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useToast } from "@uket/ui/components/ui/use-toast";
 import {
   Dialog,
   DialogClose,
@@ -20,29 +19,12 @@ interface ConfirmModalProps {
 
 function ConfirmModal(props: ConfirmModalProps) {
   const { ticketId } = props;
-  const { toast } = useToast();
-
   const [open, setOpen] = useState(false);
-
-  const mutation = useMutationCancelTicket();
+  const { mutate } = useMutationCancelTicket();
 
   const handleCancel = () => {
-    mutation.mutate(ticketId, {
-      onSuccess: () => {
-        setOpen(false);
-        toast({
-          title: "티켓 취소 성공!",
-        });
-      },
-      onError: () => {
-        setOpen(false);
-        toast({
-          variant: "destructive",
-          title: "오류",
-          description: "티켓 취소 중 오류가 발생했습니다. 다시 시도해주세요.",
-        });
-      },
-    });
+    setOpen(false);
+    mutate(ticketId);
   };
 
   return (

--- a/apps/soritor/src/pages/ticket-list/_components/Deposit.tsx
+++ b/apps/soritor/src/pages/ticket-list/_components/Deposit.tsx
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-import { useToast } from "@uket/ui/components/ui/use-toast";
 import { Button } from "@uket/ui/components/ui/button";
 
 import { useQueryDepositUrl } from "@/hooks/queries/useQueryDepositUrl";
@@ -16,8 +15,6 @@ interface DepositProps {
 
 const Deposit = (props: DepositProps) => {
   const { ticketId, eventId, ticketStatus: isDepositActive } = props;
-
-  const { toast } = useToast();
 
   const { data: deposit } = useQueryDepositUrl(
     ticketId,
@@ -64,7 +61,7 @@ const Deposit = (props: DepositProps) => {
                 variant="link"
                 className="text-brand cursor-pointer px-1 font-bold"
                 onClick={() =>
-                  handleCopyClipBoard(deposit?.accountNumber ?? "", toast)
+                  handleCopyClipBoard(deposit?.accountNumber ?? "")
                 }
               >
                 복사

--- a/apps/soritor/src/types/index.d.ts
+++ b/apps/soritor/src/types/index.d.ts
@@ -1,0 +1,7 @@
+import CustomAxiosError from "@/utils/customError";
+
+declare module "@tanstack/react-query" {
+  interface Register {
+    defaultError: CustomAxiosError;
+  }
+}

--- a/apps/soritor/src/utils/customError.ts
+++ b/apps/soritor/src/utils/customError.ts
@@ -3,10 +3,10 @@ import { AxiosError } from "axios";
 // AxiosError를 확장한 커스텀 에러 클래스
 class CustomAxiosError extends AxiosError {
   isToast: boolean;
-  errorContent: { title: string; description: string } | null;
+  errorContent: { title: string; description?: string } | null;
   constructor(
     error: AxiosError,
-    errorContent: { title: string; description: string } | null = null,
+    errorContent: { title: string; description?: string } | null = null,
     isToast: boolean = false, // isToast 기본 값은 false
   ) {
     super(error.message, error.code);

--- a/apps/soritor/src/utils/customError.ts
+++ b/apps/soritor/src/utils/customError.ts
@@ -1,0 +1,22 @@
+import { AxiosError } from "axios";
+
+// AxiosError를 확장한 커스텀 에러 클래스
+class CustomAxiosError extends AxiosError {
+  isToast: boolean;
+  errorContent: { title: string; description: string } | null;
+  constructor(
+    error: AxiosError,
+    errorContent: { title: string; description: string } | null = null,
+    isToast: boolean = false, // isToast 기본 값은 false
+  ) {
+    super(error.message, error.code);
+    this.config = error.config;
+    this.request = error.request;
+    this.response = error.response;
+    /** 커스텀 필드에 값을 할당합니다. */
+    this.errorContent = errorContent;
+    this.isToast = isToast;
+  }
+}
+
+export default CustomAxiosError;

--- a/apps/soritor/src/utils/errorHandler.ts
+++ b/apps/soritor/src/utils/errorHandler.ts
@@ -5,9 +5,12 @@ import CustomAxiosError from "./customError";
 export const useHandleError = () => {
   // 토스트를 띄워줍니다.
   const errorHandler = (error: CustomAxiosError) => {
-    toast.error(`${error.errorContent?.title || "에러가 발생했어요"}`, {
-      description: error.errorContent?.description || "잠시 후 시도해 주세요.",
-    });
+    if (error.isToast) {
+      toast.error(`${error.errorContent?.title || "에러가 발생했어요"}`, {
+        description:
+          error.errorContent?.description || "잠시 후 시도해 주세요.",
+      });
+    }
   };
 
   return { errorHandler };

--- a/apps/soritor/src/utils/errorHandler.ts
+++ b/apps/soritor/src/utils/errorHandler.ts
@@ -1,0 +1,14 @@
+import { toast } from "@uket/ui/components/ui/sonner";
+
+import CustomAxiosError from "./customError";
+
+export const useHandleError = () => {
+  // 토스트를 띄워줍니다.
+  const errorHandler = (error: CustomAxiosError) => {
+    toast.error(`${error.errorContent?.title || "에러가 발생했어요"}`, {
+      description: error.errorContent?.description || "잠시 후 시도해 주세요.",
+    });
+  };
+
+  return { errorHandler };
+};

--- a/apps/soritor/src/utils/errorHandler.ts
+++ b/apps/soritor/src/utils/errorHandler.ts
@@ -2,16 +2,11 @@ import { toast } from "@uket/ui/components/ui/sonner";
 
 import CustomAxiosError from "./customError";
 
-export const useHandleError = () => {
-  // 토스트를 띄워줍니다.
-  const errorHandler = (error: CustomAxiosError) => {
-    if (error.isToast) {
-      toast.error(`${error.errorContent?.title || "에러가 발생했어요"}`, {
-        description:
-          error.errorContent?.description || "잠시 후 시도해 주세요.",
-      });
-    }
-  };
-
-  return { errorHandler };
+// 토스트를 띄워줍니다.
+export const errorHandler = (error: CustomAxiosError) => {
+  if (error.isToast) {
+    toast.error(`${error.errorContent?.title || "에러가 발생했어요"}`, {
+      description: error.errorContent?.description || "잠시 후 시도해 주세요.",
+    });
+  }
 };

--- a/apps/soritor/src/utils/globalNavigate.ts
+++ b/apps/soritor/src/utils/globalNavigate.ts
@@ -1,0 +1,20 @@
+import { NavigateOptions } from "react-router-dom";
+
+/* eslint-disable no-console */
+let globalNavigate: ReturnType<typeof import("react-router-dom").useNavigate>;
+
+const setGlobalNavigate = (navigate: typeof globalNavigate) => {
+  globalNavigate = navigate;
+};
+
+const navigateTo = (path: string, options?: NavigateOptions) => {
+  if (globalNavigate) {
+    globalNavigate(path, options);
+  } else {
+    console.log(
+      "navigateTo Function was called before navigate was initialized",
+    );
+  }
+};
+
+export { setGlobalNavigate, navigateTo };

--- a/apps/soritor/src/utils/handleCopyToClipboard.ts
+++ b/apps/soritor/src/utils/handleCopyToClipboard.ts
@@ -1,15 +1,10 @@
-export const handleCopyClipBoard = async (
-  text: string,
-  toast: (message: { title: string }) => void,
-) => {
+import { toast } from "@uket/ui/components/ui/sonner";
+
+export const handleCopyClipBoard = async (text: string) => {
   try {
     await navigator.clipboard.writeText(text);
-    toast({
-      title: "클립보드에 복사되었습니다!",
-    });
+    toast.success("클립보드에 복사되었습니다.");
   } catch (e) {
-    toast({
-      title: "클립보드에 복사에 실패했습니다!",
-    });
+    toast.error("클립보드에 복사에 실패했습니다.");
   }
 };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,6 +39,7 @@
     "lucide-react": "^0.365.0",
     "next-themes": "^0.3.0",
     "react-hook-form": "^7.51.3",
+    "sonner": "^1.7.2",
     "tailwind-merge": "^2.2.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.0",

--- a/packages/ui/src/components/ui/sonner.tsx
+++ b/packages/ui/src/components/ui/sonner.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, toast } from "sonner";
+
+type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-white group-[.toaster]:text-slate-950 group-[.toaster]:border-slate-200 group-[.toaster]:shadow-lg dark:group-[.toaster]:bg-slate-950 dark:group-[.toaster]:text-slate-50 dark:group-[.toaster]:border-slate-800",
+          description:
+            "group-[.toast]:text-slate-500 dark:group-[.toast]:text-slate-400",
+          actionButton:
+            "group-[.toast]:bg-slate-900 group-[.toast]:text-slate-50 dark:group-[.toast]:bg-slate-50 dark:group-[.toast]:text-slate-900",
+          cancelButton:
+            "group-[.toast]:bg-slate-100 group-[.toast]:text-slate-500 dark:group-[.toast]:bg-slate-800 dark:group-[.toast]:text-slate-400",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster, toast };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -517,6 +517,9 @@ importers:
       react-hook-form:
         specifier: ^7.51.3
         version: 7.51.4(react@18.3.1)
+      sonner:
+        specifier: ^1.7.2
+        version: 1.7.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^2.2.2
         version: 2.3.0
@@ -5173,6 +5176,12 @@ packages:
   socks@2.8.3:
     resolution: {integrity: sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonner@1.7.2:
+    resolution: {integrity: sha512-zMbseqjrOzQD1a93lxahm+qMGxWovdMxBlkTbbnZdNqVLt4j+amF9PQxUCL32WfztOFt9t9ADYkejAL3jF9iNA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   sort-keys-length@1.0.1:
     resolution: {integrity: sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==}
@@ -10878,6 +10887,11 @@ snapshots:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
+
+  sonner@1.7.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   sort-keys-length@1.0.1:
     dependencies:


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호

issue #152 
## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 에러 핸들링 방식 세분화 및 리팩토링

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점
### 리팩토링을 한 이유: 에러 발생 지점을 분산 관리했을 때의 문제
프론트엔드에서 에러는 에러 바운더리, Toast UI로 처리할 수 있습니다.
Toast UI의 경우 훅을 여러 곳에서 직접 호출하는 방식은 직관적으로 보일 수 있으나, 실제로 에러가 발생하는 지점이 다양해지면 해당 훅이 중복으로 작성되는 사례가 급증합니다.
특히, 코드베이스가 커질수록 어떤 컴포넌트에서 에러가 발생했는지 파악하고, 해당 컴포넌트에 정확히 훅을 배치했는지 일일히 확인하는 과정은 불편함을 야기합니다.
또한 에러 처리 로직이 파일 곳곳에 퍼져 있으면, 전체적인 유지보수 난이도가 크게 높아집니다. 예컨대 Toast UI 훅 코드가 하나만 수정되어도, 그 코드가 호출되는 다른 모든 컴포넌트에서 모듈을 검토해야 할 가능성이 높습니다.

이는 작은 기능 변경으로도 코드 전반에 손길이 닿아야 한다는 의미여서, 에러 관리 정책을 통일하기 어렵게 만듭니다.

### 문제점: 기존 코드베이스
네트워크 요청은 크게 2가지로 나눌 수 있습니다.
1. query(get)
2. mutation(post, delete, ...)

현재 저희 코드베이스에서 query는 거의 대부분 `useSuspenseQuery`를 사용하고 있습니다. 이는 에러 발생 시, 자동으로 에러를 상위로 전파하여 `ErrorBoundary`로 처리합니다. (Toast UI로 처리하는 코드는 없습니다.)

반면, mutation의 일부는 `onSuccess, onError`시 Toast UI를 사용하고 있습니다.

예를 들어, 기존의 회원탈퇴 컴포넌트는 아래와 같았습니다.
```tsx
const DeleteUserInfoModal = () => {
  const { toast } = useToast();

  const [open, setOpen] = useState(false);

  const navigate = useNavigate();

  const mutation = useMutationDeleteUser(); // mutation

  const handleDeleteUserInfo = () => {
    setOpen(false);
    mutation.mutate(undefined, {
      onSuccess: () => {
        toast({
          title: "회원탈퇴 성공!",
        });
        navigate("/", { replace: true });
      },
      onError: () => {
        toast({
          title: "회원탈퇴 실패",
          variant: "brandDestructive",
        });
      },
    });
  };

  return (...);
```
이 외에도 `ConfirmModal`도 동일한 형식의 코드베이스를 가지고 있습니다.

여기서 위에서 언급한 문제가 발생합니다. 토스트 메시지를 수정하거나, 토스트 UI 코드 자체를 수정할 경우 일일히 해당 코드가 사용되는 지점을 모두 파악하여 수정을 해야합니다. 또한, `useToast`훅을 매번 추가해야 합니다.

### 리팩토링: 중앙 집중식 에러 핸들링 마련
이 같은 비효율성을 해소하기 위해, 에러를 한 군데에서 집중적으로 모니터링하고 처리하는 구조를 도입했습니다.
즉, 에러 처리 로직이 하나의 ‘입구'로 모이도록 만들어, 별도의 모듈이나 컴포넌트가 에러 메시지를 띄우고 관리하는 과정을 반자동화했습니다.

개선된 흐름은 아래와 같습니다. 자세한 내용은 [이곳](https://coggiee.medium.com/error-handling-error-boundary-toast-ui-0f9704e0a824)을 참고해 주세요. (하단의 이미지는 query 기준으로 작성되었습니다. mutation도 이와 유사합니다.)
![무제 001](https://github.com/user-attachments/assets/81343d15-4e45-4b99-a4fb-d97eb7137b78)

### 주요 변경 사항
#### #1 네트워크 요청 방식 변경
**instance 대신 fetcher를 사용해 주세요.**
```tsx
// 기존
await instance.get(url, config);

// 변경
await fetcher.get(url, {
  mode: "TOAST_UI" // or "BOUNDARY", // 에러 처리 방식을 설정
  errorContent: { // 토스트 UI 방식으로 처리할 때, 토스트에 보여줄 메시지
    title: 'Toast Error Title',
    description: 'Toast Error Description',
  }
});
```
#### #2 에러 처리 방식 설정하기
네트워크 요청을 보낼 때 `config` 인자에 추가적인 필드를 설정할 수 있습니다. (config는 AxiosRequestConfig를 상속합니다.)
- mode: 에러 처리 방식을 설정하는 필드 (기본값: "BOUDNARY" -> 에러 바운더리)
- errorConent: 토스트 방식일 때, 토스트에 보여줄 메시지를 담는 객체 (값을 전달하지 않으면 default 값이 사용됩니다.)

위 필드만 설정하면, 에러가 발생했을 때 추가적으로 토스트 훅을 호출하지 않아도 됩니다.
#### #3 Toast -> Sonner
Sonner는 토스트의 일종으로 업그레이드된 Toast라고 합니다. (둘 모두 shadcn 컴포넌트)
토스트를 띄워주는 `errorHandler.ts`에서, Toast 훅을 호출할 수 없는 문제가 있어 Sonner로 변경했습니다.
(Toast는 내부적으로 `useState, useEffect`를 사용해서 컴포넌트 내부가 아니면 호출이 불가능한 것으로 보입니다.)

#### #4 mutation 성공 상태 관리
기존 코드 베이스에서 mutation이 성공했을 때 토스트를 띄워주는 코드가 분산되어 있었습니다.
이를 하나로 묶어서, `QueryClient.defaultOptions.mutations.onSuccess`에서 중앙 집중 관리를 할 수 있게 변경했습니다.

이때, 토스트를 사용해야 하는 mutation의 경우 아래와 같이 사용해야 합니다.
```tsx
const mutation = useMutation({
    mutationFn: deleteUserInfo,
    onMutate: () => { // 반드시 추가해야 합니다.
      return { mutationKey: "deleteUser" };
    },
});
```
`onMutate` 함수에서 mutationKey를 반환합니다. 해당 필드는 어떤 토스트 메시지를 보여줄 지 결정하기 위해 사용하는 **키** 입니다.

해당 키는 상수로 관리합니다. 
```tsx
// constants/success_toast.ts
export const SUCCESS_TOAST = {
  deleteUser: {
    onSuccess: () => {
      navigateTo("/", { replace: true });
      toast.success("정상적으로 탈퇴되었습니다.");
    },
  },
  cancelTicket: {
    onSuccess: () => {
      toast.success("예매가 취소되었습니다.");
    },
  },
};

// QueryProvider.tsx
new QueryClient({
...,
onSuccess: (data, _, context) => {
        const mutationKey = (context as any)
          ?.mutationKey as keyof typeof SUCCESS_TOAST;
        if (mutationKey in SUCCESS_TOAST) {
          SUCCESS_TOAST[mutationKey].onSuccess();
        }
      },
});
```

#### #5 useSuspenseQuery를 사용할 때 주의점
`useSuspenseQuery`는 에러 발생 시, 자동으로 상위로 에러를 전파하기 때문에 토스트 방식을 사용할 경우 의도치 않은 결과가 나올 수 있습니다. 때문에, `fetcher`의 `mode` 옵션의 디폴트는 "BOUNDARY" 로 설정했습니다. 
네트워크 요청이 Suspense인지 자동으로 확인하여 mode의 값을 "TOAST_UI"로 설정하지 못하도록 하고 싶었으나, Suspense인지 확인하는 방법은 없는 것으로 보입니다. 그래서 항상 `ErrorBoundary`로 감싸야 합니다.

`useQuery`는 방식은 요구사항에 맞게 mode를 설정하시면 됩니다.

### 추가) 글로벌 `useNavigate` 설정
**`.ts` 파일의 경우 SPA의 페이지를 이동하는 훅인 useNavigate 를 사용할 수 없습니다.**

기능 요구사항에 따르면, 토스트를 띄우고 경로를 이동해야 하는 케이스가 존재합니다. 하지만, 토스트를 관리하는 `success-toast.ts, errorHandler.ts`의 확장자가 `.ts`이기 때문에 해당 훅을 사용할 수 가 없었습니다.
`useNavigate`와 유사한 `window.location.href`는 **하드 리프레시**를 수행하기 때문에, 페이지의 상태 및 React 앱 상태, 컴포넌트 트리가 모두 초기화됩니다. 그래서 토스트가 화면에 유지되지 않고 바로 사라지게 됩니다.

그래서, `useNavigate`를 글로벌에서 사용할 수 있도록 추가했습니다.
```tsx
// utils/globalNavigate.ts
import { NavigateOptions } from "react-router-dom";

/* eslint-disable no-console */
let globalNavigate: ReturnType<typeof import("react-router-dom").useNavigate>;

const setGlobalNavigate = (navigate: typeof globalNavigate) => {
  globalNavigate = navigate;
};

// 이 함수를 사용합니다.
const navigateTo = (path: string, options?: NavigateOptions) => {
  if (globalNavigate) {
    globalNavigate(path, options);
  } else {
    console.log(
      "navigateTo Function was called before navigate was initialized",
    );
  }
};

export { setGlobalNavigate, navigateTo };
```


## 💬 리뷰 요구사항(선택)


---
🚨 **이슈를 닫아주세요!**
> ex) close #이슈번호

close #152 